### PR TITLE
Feat: Catalogs::PricingRuleCreator で価格ルール作成時の価格存在検証を実装

### DIFF
--- a/app/models/catalogs/pricing_rule_creator.rb
+++ b/app/models/catalogs/pricing_rule_creator.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+module Catalogs
+  # 価格ルール作成・更新 PORO
+  #
+  # 価格ルール（CatalogPricingRule）の作成・更新時に、参照する価格種別（kind）に
+  # 対応する CatalogPrice が存在することを検証する。
+  #
+  # ActiveModel::Validations を使用して Rails 標準のバリデーションパターンに従う。
+  #
+  # @example 基本的な使い方
+  #   creator = Catalogs::PricingRuleCreator.new(target_catalog: catalog)
+  #   rule = creator.create(price_kind: :bundle, trigger_category: :bento, ...)
+  #
+  # @example 更新
+  #   creator = Catalogs::PricingRuleCreator.new(target_catalog: rule.target_catalog)
+  #   updated_rule = creator.update(rule, max_per_trigger: 2)
+  #
+  class PricingRuleCreator
+    include ActiveModel::Validations
+
+    attr_reader :target_catalog, :rule
+
+    validate :validate_price_existence, if: :currently_active?
+
+    # @param target_catalog [Catalog] 価格ルールを適用する商品
+    def initialize(target_catalog:)
+      @target_catalog = target_catalog
+    end
+
+    # 価格ルールを新規作成
+    #
+    # @param rule_params [Hash] ルールパラメータ
+    # @option rule_params [Symbol, String] :price_kind 価格種別 (:regular, :bundle)
+    # @option rule_params [Symbol, String] :trigger_category トリガーカテゴリ (:bento, :side_menu)
+    # @option rule_params [Integer] :max_per_trigger トリガー1個あたりの最大適用数
+    # @option rule_params [Date] :valid_from 有効開始日
+    # @option rule_params [Date, nil] :valid_until 有効終了日（nil で無期限）
+    # @return [CatalogPricingRule] 作成されたルール
+    # @raise [Errors::MissingPriceError] 今日時点で有効なルールに対応する価格が存在しない場合
+    # @raise [ActiveRecord::RecordInvalid] バリデーションエラーの場合
+    def create(rule_params)
+      @rule = CatalogPricingRule.new(rule_params.merge(target_catalog: target_catalog))
+      validate_and_save!
+    end
+
+    # 価格ルールを更新
+    #
+    # @param existing_rule [CatalogPricingRule] 更新対象のルール
+    # @param rule_params [Hash] 更新パラメータ
+    # @return [CatalogPricingRule] 更新されたルール
+    # @raise [Errors::MissingPriceError] 更新後に今日時点で有効になり、対応する価格が存在しない場合
+    # @raise [ActiveRecord::RecordInvalid] バリデーションエラーの場合
+    def update(existing_rule, rule_params)
+      @rule = existing_rule
+      rule.assign_attributes(rule_params)
+      validate_and_save!
+    end
+
+    private
+
+    # 価格存在を検証してルールを保存
+    #
+    # @return [CatalogPricingRule] 保存されたルール
+    # @raise [Errors::MissingPriceError] 価格が存在しない場合
+    def validate_and_save!
+      raise Errors::MissingPriceError.new(missing_price_details) unless valid?
+
+      rule.save!
+      rule
+    end
+
+    # 今日時点で有効かどうかを判定
+    #
+    # @return [Boolean] 今日時点で有効な場合は true
+    def currently_active?
+      return false unless rule&.valid_from
+
+      today = Date.current
+      started = rule.valid_from <= today
+      not_ended = rule.valid_until.nil? || rule.valid_until >= today
+
+      started && not_ended
+    end
+
+    # 価格存在検証（ActiveModel::Validations のカスタムバリデーション）
+    def validate_price_existence
+      return if price_exists?
+
+      errors.add(:base, :missing_price, catalog_name: target_catalog.name, price_kind: rule.price_kind)
+    end
+
+    # 対象カタログに指定価格種別が存在するか
+    #
+    # @return [Boolean]
+    def price_exists?
+      Catalogs::PriceValidator.new(at: Date.current).price_exists?(target_catalog, rule.price_kind)
+    end
+
+    # MissingPriceError 用の詳細情報
+    #
+    # @return [Array<Hash>] 欠損価格の詳細
+    def missing_price_details
+      [ {
+        catalog_id: target_catalog.id,
+        catalog_name: target_catalog.name,
+        price_kind: rule.price_kind.to_s
+      } ]
+    end
+  end
+end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,4 +1,12 @@
 ja:
+  activemodel:
+    errors:
+      models:
+        catalogs/pricing_rule_creator:
+          attributes:
+            base:
+              missing_price: "商品「%{catalog_name}」に価格種別「%{price_kind}」の価格が設定されていません"
+
   activerecord:
     models:
       admin: "管理者"

--- a/docs/specs/sales-tracking-pos/tasks.md
+++ b/docs/specs/sales-tracking-pos/tasks.md
@@ -290,25 +290,25 @@
   - トランザクション開始前に検証が完了するため、在庫減算なし
   - _Requirements: 17.5, 17.6, 17.7_
 
-- [ ] 42. Catalogs::PricingRuleCreator（価格ルール作成 PORO）実装
-- [ ] 42.1 Catalogs::PricingRuleCreator クラス作成
+- [x] 42. Catalogs::PricingRuleCreator（価格ルール作成 PORO）実装
+- [x] 42.1 Catalogs::PricingRuleCreator クラス作成
   - app/models/catalogs ディレクトリ内に PricingRuleCreator クラス作成
-  - MissingPriceError は Catalogs::PriceValidator::MissingPriceError を再利用
+  - MissingPriceError は Errors::MissingPriceError を再利用
   - _Requirements: 19.1, 19.3, 19.4_
 
-- [ ] 42.2 create メソッド実装
+- [x] 42.2 create メソッド実装
   - CatalogPricingRule のインスタンス作成
   - 今日時点で有効化される場合は価格存在検証を実行
   - 検証成功時のみ save! を実行
   - _Requirements: 19.1, 19.5, 19.6_
 
-- [ ] 42.3 update メソッド実装
+- [x] 42.3 update メソッド実装
   - 既存 CatalogPricingRule の属性更新
   - 有効化（active）される場合は価格存在検証を実行
   - 無効化（inactive）の場合は検証をスキップ
   - _Requirements: 19.2, 19.5, 19.6, 19.7_
 
-- [ ] 42.4 validate_price_existence! プライベートメソッド実装
+- [x] 42.4 validate_price_existence! プライベートメソッド実装
   - 参照する価格種別（kind）に対応する CatalogPrice の存在確認
   - 今日時点（Date.current）で有効な価格のみを検証対象
   - 不足時は MissingPriceError を発生

--- a/docs/steering/testing.md
+++ b/docs/steering/testing.md
@@ -73,6 +73,8 @@ end
 | sale_test.rb | `:locations, :employees, :sales` |
 | sale_item_test.rb | `:locations, :employees, :catalogs, :catalog_prices, :sales, :sale_items` |
 | sales/recorder_test.rb | `:locations, :employees, :catalogs, :catalog_prices, :daily_inventories` |
+| catalogs/price_validator_test.rb | `:catalogs, :catalog_prices, :catalog_pricing_rules` |
+| catalogs/pricing_rule_creator_test.rb | `:catalogs, :catalog_prices, :catalog_pricing_rules` |
 | admin_authentication_test.rb | `:admins` |
 | employee_authentication_test.rb | `:employees` |
 | error_handling_test.rb | `:admins, :employees` |

--- a/test/models/catalogs/pricing_rule_creator_test.rb
+++ b/test/models/catalogs/pricing_rule_creator_test.rb
@@ -1,0 +1,244 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Catalogs::PricingRuleCreatorTest < ActiveSupport::TestCase
+  fixtures :catalogs, :catalog_prices, :catalog_pricing_rules
+
+  # ===== Task 42.1: クラス構造 =====
+
+  test "target_catalog を受け取ってインスタンスを作成できる" do
+    catalog = catalogs(:salad)
+    creator = Catalogs::PricingRuleCreator.new(target_catalog: catalog)
+
+    assert_kind_of Catalogs::PricingRuleCreator, creator
+  end
+
+  # ===== Task 42.2: create メソッド =====
+
+  test "create は今日時点で有効な価格が存在する場合にルールを作成する" do
+    # salad には bundle 価格が設定されている
+    catalog = catalogs(:salad)
+    creator = Catalogs::PricingRuleCreator.new(target_catalog: catalog)
+
+    rule_params = {
+      price_kind: :bundle,
+      trigger_category: :bento,
+      max_per_trigger: 2,
+      valid_from: Date.current,
+      valid_until: nil
+    }
+
+    assert_difference "CatalogPricingRule.count" do
+      rule = creator.create(rule_params)
+      assert_kind_of CatalogPricingRule, rule
+      assert_equal catalog.id, rule.target_catalog_id
+      assert_equal "bundle", rule.price_kind
+      assert_equal 2, rule.max_per_trigger
+    end
+  end
+
+  test "create は価格が存在しない場合に MissingPriceError を発生させる" do
+    # miso_soup には価格が設定されていない
+    catalog = catalogs(:miso_soup)
+    creator = Catalogs::PricingRuleCreator.new(target_catalog: catalog)
+
+    rule_params = {
+      price_kind: :regular,
+      trigger_category: :bento,
+      max_per_trigger: 1,
+      valid_from: Date.current,
+      valid_until: nil
+    }
+
+    error = assert_raises(Errors::MissingPriceError) do
+      creator.create(rule_params)
+    end
+
+    assert_equal 1, error.missing_prices.length
+    assert_equal "味噌汁", error.missing_prices.first[:catalog_name]
+    assert_equal "regular", error.missing_prices.first[:price_kind]
+    assert_match(/味噌汁/, error.message)
+  end
+
+  test "create は bundle 価格が存在しない場合に MissingPriceError を発生させる" do
+    # daily_bento_a には bundle 価格が設定されていない
+    catalog = catalogs(:daily_bento_a)
+    creator = Catalogs::PricingRuleCreator.new(target_catalog: catalog)
+
+    rule_params = {
+      price_kind: :bundle,
+      trigger_category: :side_menu,
+      max_per_trigger: 1,
+      valid_from: Date.current,
+      valid_until: nil
+    }
+
+    error = assert_raises(Errors::MissingPriceError) do
+      creator.create(rule_params)
+    end
+
+    assert_equal "bundle", error.missing_prices.first[:price_kind]
+  end
+
+  test "create はバリデーションエラーの場合に RecordInvalid を発生させる" do
+    catalog = catalogs(:salad)
+    creator = Catalogs::PricingRuleCreator.new(target_catalog: catalog)
+
+    rule_params = {
+      price_kind: :bundle,
+      trigger_category: nil, # 必須項目が欠落
+      max_per_trigger: 1,
+      valid_from: Date.current
+    }
+
+    assert_raises(ActiveRecord::RecordInvalid) do
+      creator.create(rule_params)
+    end
+  end
+
+  test "create は将来の valid_from の場合は価格存在検証をスキップする" do
+    # miso_soup には価格が設定されていない
+    catalog = catalogs(:miso_soup)
+    creator = Catalogs::PricingRuleCreator.new(target_catalog: catalog)
+
+    rule_params = {
+      price_kind: :regular,
+      trigger_category: :bento,
+      max_per_trigger: 1,
+      valid_from: 1.month.from_now.to_date, # 将来の日付
+      valid_until: nil
+    }
+
+    # 価格が存在しなくても、将来の valid_from なら作成できる
+    assert_difference "CatalogPricingRule.count" do
+      rule = creator.create(rule_params)
+      assert_kind_of CatalogPricingRule, rule
+    end
+  end
+
+  test "create は今日より前の valid_from でも今日時点で有効なら検証する" do
+    # miso_soup には価格が設定されていない
+    catalog = catalogs(:miso_soup)
+    creator = Catalogs::PricingRuleCreator.new(target_catalog: catalog)
+
+    rule_params = {
+      price_kind: :regular,
+      trigger_category: :bento,
+      max_per_trigger: 1,
+      valid_from: 1.week.ago.to_date, # 過去の日付だが有効
+      valid_until: nil
+    }
+
+    # 過去の valid_from でも今日時点で有効なら検証される
+    assert_raises(Errors::MissingPriceError) do
+      creator.create(rule_params)
+    end
+  end
+
+  test "create は今日より前に終了する valid_until の場合は価格存在検証をスキップする" do
+    # miso_soup には価格が設定されていない
+    catalog = catalogs(:miso_soup)
+    creator = Catalogs::PricingRuleCreator.new(target_catalog: catalog)
+
+    rule_params = {
+      price_kind: :regular,
+      trigger_category: :bento,
+      max_per_trigger: 1,
+      valid_from: 1.month.ago.to_date,
+      valid_until: 1.week.ago.to_date # 既に終了
+    }
+
+    # 既に無効なルールなら価格検証をスキップ
+    assert_difference "CatalogPricingRule.count" do
+      rule = creator.create(rule_params)
+      assert_kind_of CatalogPricingRule, rule
+    end
+  end
+
+  # ===== Task 42.3: update メソッド =====
+
+  test "update は今日時点で有効になるルールの価格存在を検証する" do
+    rule = catalog_pricing_rules(:salad_bundle_by_bento)
+    creator = Catalogs::PricingRuleCreator.new(target_catalog: rule.target_catalog)
+
+    # salad には bundle 価格が存在するので更新できる
+    assert_no_difference "CatalogPricingRule.count" do
+      updated_rule = creator.update(rule, max_per_trigger: 3)
+      assert_equal 3, updated_rule.max_per_trigger
+    end
+  end
+
+  test "update は将来のルールを更新する場合は価格存在検証をスキップする" do
+    # 価格が存在しない miso_soup で、将来から有効なルールを作成
+    catalog = catalogs(:miso_soup)
+    rule = CatalogPricingRule.create!(
+      target_catalog: catalog,
+      price_kind: :regular,
+      trigger_category: :bento,
+      max_per_trigger: 1,
+      valid_from: 1.month.from_now.to_date,
+      valid_until: nil
+    )
+
+    creator = Catalogs::PricingRuleCreator.new(target_catalog: catalog)
+
+    # 将来のルールに valid_until を設定しても、今日時点では有効でないので検証不要
+    updated_rule = creator.update(rule, valid_until: 2.months.from_now.to_date)
+    assert_equal 2.months.from_now.to_date, updated_rule.valid_until
+  end
+
+  test "update は将来に有効化する場合は価格存在検証をスキップする" do
+    # miso_soup には価格が設定されていない
+    catalog = catalogs(:miso_soup)
+
+    # 将来から有効なルールを作成
+    rule = CatalogPricingRule.create!(
+      target_catalog: catalog,
+      price_kind: :regular,
+      trigger_category: :bento,
+      max_per_trigger: 1,
+      valid_from: 1.month.from_now.to_date,
+      valid_until: nil
+    )
+
+    creator = Catalogs::PricingRuleCreator.new(target_catalog: catalog)
+
+    # 将来のままなら更新可能
+    updated_rule = creator.update(rule, max_per_trigger: 2)
+    assert_equal 2, updated_rule.max_per_trigger
+  end
+
+  test "update は将来のルールを今日から有効にする場合は価格存在を検証する" do
+    # miso_soup には価格が設定されていない
+    catalog = catalogs(:miso_soup)
+
+    # 将来から有効なルールを作成
+    rule = CatalogPricingRule.create!(
+      target_catalog: catalog,
+      price_kind: :regular,
+      trigger_category: :bento,
+      max_per_trigger: 1,
+      valid_from: 1.month.from_now.to_date,
+      valid_until: nil
+    )
+
+    creator = Catalogs::PricingRuleCreator.new(target_catalog: catalog)
+
+    # 今日から有効にすると価格検証が発生
+    error = assert_raises(Errors::MissingPriceError) do
+      creator.update(rule, valid_from: Date.current)
+    end
+
+    assert_equal "味噌汁", error.missing_prices.first[:catalog_name]
+  end
+
+  test "update は RecordInvalid を発生させる" do
+    rule = catalog_pricing_rules(:salad_bundle_by_bento)
+    creator = Catalogs::PricingRuleCreator.new(target_catalog: rule.target_catalog)
+
+    assert_raises(ActiveRecord::RecordInvalid) do
+      creator.update(rule, max_per_trigger: -1) # 無効な値
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- 価格ルール（CatalogPricingRule）の作成・更新時に価格存在を検証する `Catalogs::PricingRuleCreator` PORO クラスを追加
- `ActiveModel::Validations` を使用した Rails 標準のバリデーションパターンを採用
- 今日時点で有効なルールに対してのみ検証を実行（将来・過去は対象外）

## Test plan
- [x] PricingRuleCreator のユニットテスト（13テストケース）がパス
- [ ] 全テスト（338テスト）がパス
- [ ] 価格が存在する場合にルールを作成できることを確認
- [ ] 価格が存在しない場合に MissingPriceError が発生することを確認
- [ ] 将来のルールは価格検証をスキップすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 価格ルール管理機能を追加しました。

* **バグ修正**
  * 欠落している価格に対するエラーハンドリングを改善しました。

* **テスト**
  * 価格ルール管理機能のテストカバレッジを追加しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->