### PR TITLE
Add Icon ViewComponents for reusable SVG icon management

### DIFF
--- a/app/views/components/icons/base/component.html.erb
+++ b/app/views/components/icons/base/component.html.erb
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg"
+     class="<%= css_classes %>"
+     fill="none"
+     viewBox="0 0 24 24"
+     stroke="currentColor"
+     stroke-width="<%= stroke_width %>">
+  <%= icon_path.html_safe %>
+</svg>

--- a/app/views/components/icons/base/component.rb
+++ b/app/views/components/icons/base/component.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Icons
+  module Base
+    class Component < Application::Component
+      SIZES = {
+        xs: "h-3 w-3",
+        sm: "h-4 w-4",
+        md: "h-5 w-5",
+        lg: "h-6 w-6",
+        xl: "h-8 w-8"
+      }.freeze
+
+      def initialize(size: :md, extra_class: nil, stroke_width: 2)
+        @size = size.to_sym
+        @extra_class = extra_class
+        @stroke_width = stroke_width
+      end
+
+      def icon_path
+        raise NotImplementedError, "Subclasses must define icon_path"
+      end
+
+      def css_classes
+        [ size_class, extra_class ].compact.join(" ")
+      end
+
+      attr_reader :stroke_width
+
+      private
+
+      attr_reader :size, :extra_class
+
+      def size_class
+        SIZES.fetch(size, SIZES[:md])
+      end
+    end
+  end
+end

--- a/app/views/components/icons/catalog/component.rb
+++ b/app/views/components/icons/catalog/component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Icons
+  module Catalog
+    class Component < Icons::Base::Component
+      def icon_path
+        '<path stroke-linecap="round" stroke-linejoin="round" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01" />'
+      end
+    end
+  end
+end

--- a/app/views/components/icons/close/component.rb
+++ b/app/views/components/icons/close/component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Icons
+  module Close
+    class Component < Icons::Base::Component
+      def icon_path
+        '<path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />'
+      end
+    end
+  end
+end

--- a/app/views/components/icons/error/component.rb
+++ b/app/views/components/icons/error/component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Icons
+  module Error
+    class Component < Icons::Base::Component
+      def icon_path
+        '<path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />'
+      end
+    end
+  end
+end

--- a/app/views/components/icons/home/component.rb
+++ b/app/views/components/icons/home/component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Icons
+  module Home
+    class Component < Icons::Base::Component
+      def icon_path
+        '<path stroke-linecap="round" stroke-linejoin="round" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />'
+      end
+    end
+  end
+end

--- a/app/views/components/icons/location/component.rb
+++ b/app/views/components/icons/location/component.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Icons
+  module Location
+    class Component < Icons::Base::Component
+      def icon_path
+        '<path stroke-linecap="round" stroke-linejoin="round" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />' \
+        '<path stroke-linecap="round" stroke-linejoin="round" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />'
+      end
+    end
+  end
+end

--- a/app/views/components/icons/menu/component.rb
+++ b/app/views/components/icons/menu/component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Icons
+  module Menu
+    class Component < Icons::Base::Component
+      def icon_path
+        '<path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />'
+      end
+    end
+  end
+end

--- a/app/views/components/icons/plus/component.rb
+++ b/app/views/components/icons/plus/component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Icons
+  module Plus
+    class Component < Icons::Base::Component
+      def icon_path
+        '<path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4" />'
+      end
+    end
+  end
+end

--- a/app/views/components/icons/success/component.rb
+++ b/app/views/components/icons/success/component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Icons
+  module Success
+    class Component < Icons::Base::Component
+      def icon_path
+        '<path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />'
+      end
+    end
+  end
+end

--- a/app/views/components/icons/users/component.rb
+++ b/app/views/components/icons/users/component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Icons
+  module Users
+    class Component < Icons::Base::Component
+      def icon_path
+        '<path stroke-linecap="round" stroke-linejoin="round" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />'
+      end
+    end
+  end
+end

--- a/app/views/components/locations/location_list/component.html.erb
+++ b/app/views/components/locations/location_list/component.html.erb
@@ -1,9 +1,6 @@
 <% if empty? %>
   <div class="text-center py-12 text-base-content/60">
-    <svg xmlns="http://www.w3.org/2000/svg" class="h-12 w-12 mx-auto mb-4 opacity-50" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1">
-      <path stroke-linecap="round" stroke-linejoin="round" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
-      <path stroke-linecap="round" stroke-linejoin="round" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
-    </svg>
+    <%= component "icons/location", extra_class: "h-12 w-12 mx-auto mb-4 opacity-50", stroke_width: 1 %>
     <p><%= t(".empty_message") %></p>
   </div>
 <% else %>

--- a/app/views/components/navbar/component.html.erb
+++ b/app/views/components/navbar/component.html.erb
@@ -1,9 +1,7 @@
 <div class="navbar bg-base-200 sticky top-0 z-50 backdrop-blur-sm bg-opacity-95">
   <div class="flex-none lg:hidden">
     <label for="<%= drawer_id %>" aria-label="メニューを開く" class="btn btn-square btn-ghost">
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="inline-block h-6 w-6 stroke-current">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
-      </svg>
+      <%= component "icons/menu", size: :lg, extra_class: "inline-block stroke-current" %>
     </label>
   </div>
 

--- a/app/views/components/page_header/component.html.erb
+++ b/app/views/components/page_header/component.html.erb
@@ -2,9 +2,7 @@
   <h1 class="text-2xl font-bold text-base-content"><%= title %></h1>
   <% if new_button? %>
     <%= link_to new_path, class: "btn btn-neutral", data: { turbo_stream: turbo_stream? || nil } do %>
-      <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4" />
-      </svg>
+      <%= component "icons/plus" %>
       <%= new_label %>
     <% end %>
   <% end %>

--- a/app/views/components/sidebar/component.html.erb
+++ b/app/views/components/sidebar/component.html.erb
@@ -14,7 +14,7 @@
     </li>
     <li>
       <%= link_to home_item.path, class: menu_item_class(home_item) do %>
-        <%= render_icon(home_item.icon) %>
+        <%= component "icons/#{home_item.icon}" %>
         <span><%= home_item.label %></span>
       <% end %>
     </li>
@@ -25,7 +25,7 @@
     <% admin_items.each do |item| %>
       <li>
         <%= link_to item.path, class: menu_item_class(item) do %>
-          <%= render_icon(item.icon) %>
+          <%= component "icons/#{item.icon}" %>
           <span><%= item.label %></span>
         <% end %>
       </li>

--- a/app/views/components/sidebar/component.rb
+++ b/app/views/components/sidebar/component.rb
@@ -8,13 +8,6 @@ module Sidebar
       end
     end
 
-    ICONS = {
-      home: '<svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" /></svg>',
-      users: '<svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" /></svg>',
-      location: '<svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" /><path stroke-linecap="round" stroke-linejoin="round" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" /></svg>',
-      catalog: '<svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01" /></svg>'
-    }.freeze
-
     def initialize(current_path:)
       @current_path = current_path
     end
@@ -36,10 +29,6 @@ module Sidebar
     def menu_item_class(item)
       base = "flex items-center gap-3"
       active?(item) ? "#{base} active bg-primary/10 text-primary font-medium" : "#{base} hover:bg-base-300"
-    end
-
-    def render_icon(icon_name)
-      ICONS[icon_name]&.html_safe
     end
 
     private

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,18 +14,14 @@
         <div id="flash_messages" class="mx-4 mt-4">
           <% if notice.present? %>
             <div class="alert alert-success shadow-sm mb-4">
-              <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-              </svg>
+              <%= component "icons/success", extra_class: "shrink-0" %>
               <span><%= notice %></span>
             </div>
           <% end %>
 
           <% if alert.present? %>
             <div class="alert alert-error shadow-sm mb-4">
-              <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
-              </svg>
+              <%= component "icons/error", extra_class: "shrink-0" %>
               <span><%= alert %></span>
             </div>
           <% end %>

--- a/app/views/locations/_form.html.erb
+++ b/app/views/locations/_form.html.erb
@@ -1,9 +1,7 @@
 <%= form_with model: location, url: location.persisted? ? location_path(location) : locations_path do |form| %>
   <% if location.errors.any? %>
     <div class="alert alert-error mb-4">
-      <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
-      </svg>
+      <%= component "icons/error", extra_class: "shrink-0" %>
       <div>
         <% location.errors.full_messages.each do |message| %>
           <p><%= message %></p>

--- a/app/views/locations/create.turbo_stream.erb
+++ b/app/views/locations/create.turbo_stream.erb
@@ -6,9 +6,7 @@
 <%# Flash メッセージを表示 %>
 <%= turbo_stream.prepend "flash_messages" do %>
   <div class="alert alert-success shadow-sm mb-4">
-    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-    </svg>
+    <%= component "icons/success", extra_class: "shrink-0" %>
     <span><%= t("locations.create.success") %></span>
   </div>
 <% end %>

--- a/app/views/locations/new.turbo_stream.erb
+++ b/app/views/locations/new.turbo_stream.erb
@@ -4,10 +4,8 @@
       <h3 class="text-lg font-bold mb-4"><%= t("locations.new.title") %></h3>
 
       <form method="dialog">
-        <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-          </svg>
+        <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2 modal-close-button">
+          <%= component "icons/close" %>
         </button>
       </form>
 

--- a/test/components/previews/icons_preview.rb
+++ b/test/components/previews/icons_preview.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class IconsPreview < ViewComponent::Preview
+  ICON_NAMES = %w[plus close success error home menu users location catalog].freeze
+
+  # @label 全アイコン一覧
+  def all_icons
+    render_with_template
+  end
+
+  # @label サイズ比較
+  def sizes
+    render_with_template
+  end
+end

--- a/test/components/previews/icons_preview/all_icons.html.erb
+++ b/test/components/previews/icons_preview/all_icons.html.erb
@@ -1,0 +1,7 @@
+<div class="p-8 bg-neutral min-h-screen">
+  <div class="flex flex-wrap gap-6">
+    <% IconsPreview::ICON_NAMES.each do |icon| %>
+      <%= render "Icons::#{icon.camelize}::Component".constantize.new(size: :lg, extra_class: "text-neutral-content") %>
+    <% end %>
+  </div>
+</div>

--- a/test/components/previews/icons_preview/sizes.html.erb
+++ b/test/components/previews/icons_preview/sizes.html.erb
@@ -1,0 +1,29 @@
+<div class="p-6 bg-base-100">
+  <h2 class="text-lg font-bold mb-4">Icon Sizes</h2>
+  <div class="overflow-x-auto">
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Icon</th>
+          <th>xs</th>
+          <th>sm</th>
+          <th>md</th>
+          <th>lg</th>
+          <th>xl</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% IconsPreview::ICON_NAMES.each do |icon| %>
+          <tr>
+            <td class="font-mono text-sm"><%= icon %></td>
+            <% %i[xs sm md lg xl].each do |size| %>
+              <td class="text-center">
+                <%= render "Icons::#{icon.camelize}::Component".constantize.new(size: size) %>
+              </td>
+            <% end %>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- Add `Icons::Base::Component` with shared logic for sizes, CSS classes, and stroke width
- Create 9 individual icon components: plus, close, success, error, home, menu, users, location, catalog
- Replace inline SVGs across all templates with new reusable icon components
- Remove `ICONS` constant and `render_icon` method from Sidebar component
- Add `IconsPreview` for Lookbook with grid display and size comparison views

## Test plan
- [ ] Verify all icons render correctly on `/locations` page (sidebar, page header, location list)
- [ ] Verify icons in flash messages (success/error) display properly
- [ ] Verify modal close button icon on `/locations/new`
- [ ] Check Lookbook at `/lookbook` for icon previews
- [ ] Run `bin/rails test test/components/` to ensure component tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 再利用可能なアイコンコンポーネントシステムを導入し、複数のサイズオプション（XS、SM、MD、LG、XL）に対応
  * アプリケーション全体でインラインSVGをコンポーネントベースのアイコンに統一

* **Tests**
  * アイコンプレビュー機能を追加し、すべてのアイコンと各サイズの表示を確認可能に

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->