### PR TITLE
Fix sidebar icon size being overridden by DaisyUI

### DIFF
--- a/app/views/components/icons/base/component.html.erb
+++ b/app/views/components/icons/base/component.html.erb
@@ -1,5 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
      class="<%= css_classes %>"
+     width="<%= pixel_size %>"
+     height="<%= pixel_size %>"
      fill="none"
      viewBox="0 0 24 24"
      stroke="currentColor"

--- a/app/views/components/icons/base/component.rb
+++ b/app/views/components/icons/base/component.rb
@@ -11,6 +11,14 @@ module Icons
         xl: "h-8 w-8"
       }.freeze
 
+      PIXEL_SIZES = {
+        xs: 12,
+        sm: 16,
+        md: 20,
+        lg: 24,
+        xl: 32
+      }.freeze
+
       def initialize(size: :md, extra_class: nil, stroke_width: 2)
         @size = size.to_sym
         @extra_class = extra_class
@@ -26,6 +34,10 @@ module Icons
       end
 
       attr_reader :stroke_width
+
+      def pixel_size
+        PIXEL_SIZES.fetch(size, PIXEL_SIZES[:md])
+      end
 
       private
 


### PR DESCRIPTION
## Summary
- DaisyUI v5のメニューコンポーネントがTailwind CSSのユーティリティクラスを上書きし、アイコンが~88pxで表示される問題を修正
- SVG要素に明示的なwidth/height HTML属性を追加し、CSS詳細度に関係なく一貫したサイズを保証
- `Icons::Base::Component`に`PIXEL_SIZES`定数と`pixel_size`メソッドを追加

## Test plan
- [ ] 開発サーバーを起動し、サイドバーのアイコンが20px（h-5 w-5）で表示されることを確認
- [ ] 開発者ツールでSVG要素のwidth/height属性が正しく設定されていることを確認
- [ ] 他のページでもアイコンサイズが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * アイコンコンポーネントに明示的なサイズング機能を追加しました。複数のサイズオプション（超小～超大）に対応し、各サイズが自動的に対応するピクセル値にマッピングされます。サイズが指定されていない場合はデフォルト値が使用されます。既存の機能への影響はありません。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->