### PR TITLE
fix: increase bottom padding for mobile dock navigation screens

### DIFF
--- a/app/views/components/pos/additional_orders/index_page/component.html.erb
+++ b/app/views/components/pos/additional_orders/index_page/component.html.erb
@@ -1,5 +1,5 @@
 <div class="min-h-screen bg-base-200 flex flex-col">
-  <main class="flex-1 p-4 pb-24">
+  <main class="flex-1 p-4 pb-56 lg:pb-24">
     <%# ヘルプメッセージ %>
     <div class="alert alert-info alert-soft mb-2">
       <svg class="w-5 h-5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">

--- a/app/views/components/pos/additional_orders/new_page/component.html.erb
+++ b/app/views/components/pos/additional_orders/new_page/component.html.erb
@@ -1,5 +1,5 @@
 <div class="min-h-screen bg-base-200 flex flex-col">
-  <main class="flex-1 p-4 pb-24">
+  <main class="flex-1 p-4 pb-56 lg:pb-24">
     <%= render_order_form %>
   </main>
 

--- a/app/views/components/pos/daily_inventories/new_form/component.html.erb
+++ b/app/views/components/pos/daily_inventories/new_form/component.html.erb
@@ -33,7 +33,7 @@
           </div>
 
           <%# タブパネル（スクロール領域） %>
-          <main class="flex-1 overflow-y-auto p-4 pb-24">
+          <main class="flex-1 overflow-y-auto p-4 pb-56 lg:pb-24">
             <% tab_items.each_with_index do |tab, i| %>
               <div data-tabs-target="panel" <%= "hidden" unless i == 0 %>>
                 <% case tab[:key] %>
@@ -55,7 +55,7 @@
           </main>
         </div>
       <% else %>
-        <main class="flex-1 p-4 pb-24">
+        <main class="flex-1 p-4 pb-56 lg:pb-24">
           <p class="text-center text-base-content/70 mb-6"><%= t(".instruction") %></p>
           <div class="text-center py-12 text-base-content/60">
             <%= helpers.icon "bento", extra_class: "h-12 w-12 mx-auto mb-4 opacity-50" %>


### PR DESCRIPTION
## Summary
- スマホ表示時に固定フッター + Dock ナビでコンテンツが見切れる問題を修正
- `pb-24` (96px) から `pb-56 lg:pb-24` (スマホ: 224px、デスクトップ: 96px) に変更
- 対象画面: 在庫登録、追加発注一覧、追加発注新規

## Test plan
- [ ] 開発サーバーを起動し、スマホサイズ（375px幅）で以下を確認
  - [ ] 在庫登録画面: カタログ一覧の最後までスクロール可能
  - [ ] 追加発注一覧: 発注履歴の最後までスクロール可能
  - [ ] 追加発注新規: フォームの最後までスクロール可能
- [ ] デスクトップサイズでもレイアウトが崩れていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## スタイル
* POSシステムの複数ページでレイアウトの余白を調整しました。小さい画面ではコンテンツの下部に追加の余白が表示され、大きい画面では従来通りです。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->