### PR TITLE
feat: add search functionality to daily inventory registration page

### DIFF
--- a/app/controllers/pos/locations/daily_inventories/form_states_controller.rb
+++ b/app/controllers/pos/locations/daily_inventories/form_states_controller.rb
@@ -26,7 +26,12 @@ module Pos
         end
 
         def build_form(submitted = {})
-          ::DailyInventories::InventoryForm.new(location: @location, catalogs: @catalogs, submitted: submitted)
+          ::DailyInventories::InventoryForm.new(
+            location: @location,
+            catalogs: @catalogs,
+            submitted: submitted,
+            search_query: params[:search_query]
+          )
         end
 
         def submitted_params(key)

--- a/app/frontend/controllers/search_form_controller.js
+++ b/app/frontend/controllers/search_form_controller.js
@@ -1,0 +1,26 @@
+import { Controller } from "@hotwired/stimulus"
+
+const DEBOUNCE_MS = 300
+
+// Connects to data-controller="search-form"
+export default class extends Controller {
+  static targets = ["input"]
+
+  disconnect() {
+    clearTimeout(this._timer)
+  }
+
+  search() {
+    clearTimeout(this._timer)
+    this._timer = setTimeout(() => this.#submitSearch(), DEBOUNCE_MS)
+  }
+
+  #submitSearch() {
+    const ghostForm = document.getElementById("ghost-form")
+    const queryField = ghostForm?.querySelector('[name="search_query"]')
+    if (!queryField) return
+
+    queryField.value = this.inputTarget.value
+    ghostForm.requestSubmit()
+  }
+}

--- a/app/frontend/images/icons/magnifying_glass.svg
+++ b/app/frontend/images/icons/magnifying_glass.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+  <path stroke-linecap="round" stroke-linejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" />
+</svg>

--- a/app/models/daily_inventories/inventory_form.rb
+++ b/app/models/daily_inventories/inventory_form.rb
@@ -8,28 +8,32 @@ module DailyInventories
 
     ITEM_TYPE = InventoryItemType.new
 
-    attr_reader :items, :location, :created_count
+    attr_reader :items, :location, :created_count, :search_query
 
     validate :at_least_one_item_selected
 
-    def initialize(location:, catalogs:, submitted: {})
+    def initialize(location:, catalogs:, submitted: {}, search_query: nil)
       @location = location
       @catalogs = catalogs
+      @search_query = search_query&.strip.presence
       @items = build_items(submitted)
       @created_count = 0
+    end
+
+    def visible?(item)
+      return true if @search_query.blank?
+
+      item.catalog_name.include?(@search_query)
     end
 
     def save
       return false unless valid?
 
       @created_count = DailyInventory.bulk_create(location: location, items: selected_items)
+      return true if @created_count.positive?
 
-      if @created_count > 0
-        true
-      else
-        errors.add(:base, :save_failed)
-        false
-      end
+      errors.add(:base, :save_failed)
+      false
     end
 
     def form_with_options

--- a/app/views/components/pos/daily_inventories/new_form/component.html.erb
+++ b/app/views/components/pos/daily_inventories/new_form/component.html.erb
@@ -20,9 +20,21 @@
                   data: { ghost_form_target: "originalForm" } do |f| %>
       <% if has_items? %>
         <div data-controller="tabs" class="flex flex-col flex-1 min-h-0">
-          <%# タブバー %>
-          <div class="shrink-0 bg-base-200 px-4 pt-2">
+          <%# 検索バー %>
+          <div class="shrink-0 bg-base-200 px-4 pt-2" data-controller="search-form">
             <p class="text-center text-base-content/70 mb-4"><%= t(".instruction") %></p>
+            <label class="input input-bordered flex items-center gap-2 mb-4">
+              <%= helpers.icon "magnifying_glass", extra_class: "opacity-50" %>
+              <%= search_field_tag :search_query, search_query,
+                    placeholder: t(".search_placeholder"),
+                    class: "grow text-base",
+                    autocomplete: "off", inputmode: "search",
+                    data: { search_form_target: "input", action: "input->search-form#search" } %>
+            </label>
+          </div>
+
+          <%# タブバー %>
+          <div class="shrink-0 bg-base-200 px-4">
             <div role="tablist" class="tabs tabs-lift">
               <% tab_items.each_with_index do |tab, i| %>
                 <%= button_tag tab[:label], type: :button, role: :tab,
@@ -36,20 +48,11 @@
           <main class="flex-1 overflow-y-auto p-4 pb-56 lg:pb-24">
             <% tab_items.each_with_index do |tab, i| %>
               <div data-tabs-target="panel" <%= "hidden" unless i == 0 %>>
-                <% case tab[:key] %>
-                <% when :bento %>
-                  <div class="space-y-3">
-                    <% bento_items.each do |item| %>
-                      <%= render_item_card(item) %>
-                    <% end %>
-                  </div>
-                <% when :side_menu %>
-                  <div class="space-y-3">
-                    <% side_menu_items.each do |item| %>
-                      <%= render_item_card(item) %>
-                    <% end %>
-                  </div>
-                <% end %>
+                <div class="space-y-3">
+                  <% items_for_tab(tab[:key]).each do |item| %>
+                    <%= render_item_card(item) %>
+                  <% end %>
+                </div>
               </div>
             <% end %>
           </main>

--- a/app/views/components/pos/daily_inventories/new_form/component.rb
+++ b/app/views/components/pos/daily_inventories/new_form/component.rb
@@ -12,7 +12,7 @@ module Pos
         attr_reader :location, :form
 
         delegate :items, :bento_items, :side_menu_items, :valid?, :selected_count,
-                 :form_with_options, :form_state_options, to: :form
+                 :form_with_options, :form_state_options, :search_query, to: :form
 
         def location_name
           location.name
@@ -52,16 +52,23 @@ module Pos
         def render_ghost_form
           render Pos::DailyInventories::NewFormGhostForm::Component.new(
             form_state_options: form_state_options,
-            items: items
+            items: items,
+            search_query: search_query
           )
         end
 
         def tab_items
-          @tab_items ||= begin
-            items = []
-            items << { key: :bento, label: t(".bento_tab_label") } if has_bento_items?
-            items << { key: :side_menu, label: t(".side_menu_tab_label") } if has_side_menu_items?
-            items
+          @tab_items ||= [
+            (has_bento_items? ? { key: :bento, label: t(".bento_tab_label") } : nil),
+            (has_side_menu_items? ? { key: :side_menu, label: t(".side_menu_tab_label") } : nil)
+          ].compact
+        end
+
+        def items_for_tab(key)
+          case key
+          when :bento then bento_items
+          when :side_menu then side_menu_items
+          else []
           end
         end
       end

--- a/app/views/components/pos/daily_inventories/new_form/component.yml
+++ b/app/views/components/pos/daily_inventories/new_form/component.yml
@@ -2,6 +2,7 @@
 ja:
   title_suffix: の在庫登録
   instruction: 今日持っていく商品を選んでください
+  search_placeholder: 商品名で検索...
   no_catalogs: 登録可能な商品がありません
   bento_section_title: 弁当
   side_menu_section_title: サイドメニュー

--- a/app/views/components/pos/daily_inventories/new_form_ghost_form/component.html.erb
+++ b/app/views/components/pos/daily_inventories/new_form_ghost_form/component.html.erb
@@ -1,6 +1,7 @@
 <%= form_with **form_state_options,
               id: "ghost-form",
               data: { turbo_stream: true, ghost_form_target: "ghostForm" } do |f| %>
+  <%= hidden_field_tag :search_query, search_query %>
   <% items.each do |item| %>
     <%= hidden_field_tag "ghost_inventory[#{item.catalog_id}][selected]", item.selected? ? "1" : "0" %>
     <%= hidden_field_tag "ghost_inventory[#{item.catalog_id}][stock]", item.stock %>

--- a/app/views/components/pos/daily_inventories/new_form_ghost_form/component.rb
+++ b/app/views/components/pos/daily_inventories/new_form_ghost_form/component.rb
@@ -4,12 +4,13 @@ module Pos
   module DailyInventories
     module NewFormGhostForm
       class Component < Application::Component
-        def initialize(form_state_options:, items:)
+        def initialize(form_state_options:, items:, search_query: nil)
           @form_state_options = form_state_options
           @items = items
+          @search_query = search_query
         end
 
-        attr_reader :form_state_options, :items
+        attr_reader :form_state_options, :items, :search_query
       end
     end
   end

--- a/app/views/components/pos/daily_inventories/new_form_item_card/component.html.erb
+++ b/app/views/components/pos/daily_inventories/new_form_item_card/component.html.erb
@@ -1,5 +1,6 @@
 <%= fields_for item_field_name, item do |f| %>
-  <div id="<%= dom_id %>" class="<%= card_classes %>">
+  <div id="<%= dom_id %>" class="<%= wrapper_classes %>">
+  <div class="<%= card_classes %>">
     <div class="card-body p-4">
       <%# カード選択エリア %>
       <label class="flex items-center gap-3 cursor-pointer">
@@ -31,5 +32,6 @@
         </div>
       <% end %>
     </div>
+  </div>
   </div>
 <% end %>

--- a/app/views/components/pos/daily_inventories/new_form_item_card/component.rb
+++ b/app/views/components/pos/daily_inventories/new_form_item_card/component.rb
@@ -4,13 +4,18 @@ module Pos
   module DailyInventories
     module NewFormItemCard
       class Component < Application::Component
-        def initialize(item:)
+        def initialize(item:, hidden: false)
           @item = item
+          @hidden = hidden
         end
 
         attr_reader :item
 
         delegate :catalog_id, :catalog_name, :selected?, :stock, to: :item
+
+        def hidden?
+          @hidden
+        end
 
         def dom_id
           "item-card-#{catalog_id}"
@@ -18,6 +23,10 @@ module Pos
 
         def item_field_name
           "inventory[#{catalog_id}]"
+        end
+
+        def wrapper_classes
+          class_names("hidden": hidden?)
         end
 
         def card_classes

--- a/app/views/pos/locations/daily_inventories/form_states/create.turbo_stream.erb
+++ b/app/views/pos/locations/daily_inventories/form_states/create.turbo_stream.erb
@@ -2,7 +2,8 @@
 <% @form.items.each do |item| %>
   <%= turbo_stream.replace "item-card-#{item.catalog_id}" do %>
     <%= component "pos/daily_inventories/new_form_item_card",
-                  item: item %>
+                  item: item,
+                  hidden: !@form.visible?(item) %>
   <% end %>
 <% end %>
 
@@ -17,5 +18,6 @@
 <%= turbo_stream.replace "ghost-form" do %>
   <%= component "pos/daily_inventories/new_form_ghost_form",
                 form_state_options: @form.form_state_options,
-                items: @form.items %>
+                items: @form.items,
+                search_query: @form.search_query %>
 <% end %>

--- a/test/models/daily_inventories/inventory_form_test.rb
+++ b/test/models/daily_inventories/inventory_form_test.rb
@@ -113,6 +113,43 @@ module DailyInventories
     end
 
     # =====================================================================
+    # 検索機能テスト
+    # =====================================================================
+
+    test "visible? returns true when search_query is blank" do
+      form = InventoryForm.new(location: @location, catalogs: @catalogs)
+      item = form.items.first
+
+      assert form.visible?(item)
+    end
+
+    test "visible? returns true when item name matches search_query" do
+      form = InventoryForm.new(location: @location, catalogs: @catalogs, search_query: @bento_a.name[0..2])
+      item = form.items.find { |i| i.catalog_id == @bento_a.id }
+
+      assert form.visible?(item)
+    end
+
+    test "visible? returns false when item name does not match search_query" do
+      form = InventoryForm.new(location: @location, catalogs: @catalogs, search_query: "存在しない商品名")
+      item = form.items.first
+
+      assert_not form.visible?(item)
+    end
+
+    test "search_query is stripped and normalized" do
+      form = InventoryForm.new(location: @location, catalogs: @catalogs, search_query: "  弁当  ")
+
+      assert_equal "弁当", form.search_query
+    end
+
+    test "search_query empty string becomes nil" do
+      form = InventoryForm.new(location: @location, catalogs: @catalogs, search_query: "   ")
+
+      assert_nil form.search_query
+    end
+
+    # =====================================================================
     # save メソッドテスト
     # =====================================================================
 


### PR DESCRIPTION
## Summary
- POS日次在庫登録ページに弁当検索機能を追加
- 既存のGhost Form + Turbo Streamパターンを拡張し、バックエンド中心のフィルタリングを実装
- 300msのdebounce付き検索入力でリアルタイムに商品をフィルタリング

## Test plan
- [ ] `bin/dev` でサーバー起動
- [ ] POS画面 → 販売先選択 → 在庫登録ページへ移動
- [ ] 検索フィールドに文字を入力し、300ms後にマッチしない商品が非表示になることを確認
- [ ] 弁当を選択し、検索中も選択状態が保持されることを確認
- [ ] 検索をクリアして全商品が表示されることを確認
- [ ] 「販売開始」ボタンが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 日次棚卸フォームに商品検索機能を追加しました。検索バーを使用して商品名で簡単にフィルタリングできます。リアルタイム検索でスムーズな操作をサポートしています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->