### PR TITLE
feat: Catalog モデルに kana（ふりがな）フィールドを追加

### DIFF
--- a/app/controllers/catalogs_controller.rb
+++ b/app/controllers/catalogs_controller.rb
@@ -61,11 +61,11 @@ class CatalogsController < ApplicationController
   end
 
   def catalog_params
-    params.require(:catalog).permit(:name, :category, :description)
+    params.require(:catalog).permit(:name, :kana, :category, :description)
   end
 
   def catalog_create_params
-    params.require(:catalog).permit(:name, :category, :description, :regular_price, :bundle_price)
+    params.require(:catalog).permit(:name, :kana, :category, :description, :regular_price, :bundle_price)
   end
 
   def handle_create_error

--- a/app/controllers/pos/locations/additional_orders_controller.rb
+++ b/app/controllers/pos/locations/additional_orders_controller.rb
@@ -43,7 +43,7 @@ module Pos
         @inventories = @location.today_inventories
                                 .eager_load(:catalog)
                                 .merge(Catalog.where(category: :bento))
-                                .order("catalogs.name")
+                                .order("catalogs.kana")
       end
 
       def set_additional_orders

--- a/app/models/catalogs/base_creator.rb
+++ b/app/models/catalogs/base_creator.rb
@@ -11,6 +11,7 @@ module Catalogs
     include ActiveModel::Attributes
 
     attribute :name, :string
+    attribute :kana, :string
     attribute :description, :string, default: ""
     attribute :regular_price, :integer
 
@@ -19,7 +20,7 @@ module Catalogs
 
     # 構築したカタログを返す（バリデーションと保存で同じインスタンスを使用）
     def built_catalog
-      @catalog ||= Catalog.new(name: name, category: category, description: description)
+      @catalog ||= Catalog.new(name: name, kana: kana, category: category, description: description)
     end
 
     # 外部から参照するためのエイリアス

--- a/app/views/components/catalogs/basic_info_form/component.html.erb
+++ b/app/views/components/catalogs/basic_info_form/component.html.erb
@@ -32,6 +32,20 @@
             <p class="text-sm text-error mt-1"><%= error.full_message %></p>
           <% end %>
         </div>
+
+        <%# フリガナフィールド %>
+        <div class="form-control w-full mt-4">
+          <%= f.label :kana, class: "label" do %>
+            <span class="label-text font-medium"><%= Catalog.human_attribute_name(:kana) %></span>
+          <% end %>
+          <%= f.text_field :kana,
+              required: true,
+              class: "input input-bordered w-full #{catalog.errors[:kana].any? ? 'input-error' : ''}",
+              placeholder: t(".placeholder.kana") %>
+          <% catalog.errors.where(:kana).each do |error| %>
+            <p class="text-sm text-error mt-1"><%= error.full_message %></p>
+          <% end %>
+        </div>
       <% end %>
     </div>
   </section>

--- a/app/views/components/catalogs/basic_info_form/component.yml
+++ b/app/views/components/catalogs/basic_info_form/component.yml
@@ -4,3 +4,4 @@ ja:
   update: 更新する
   placeholder:
     name: "例: のり弁当"
+    kana: "例: ノリベントウ"

--- a/app/views/components/catalogs/bento_fields/component.html.erb
+++ b/app/views/components/catalogs/bento_fields/component.html.erb
@@ -20,6 +20,26 @@
     <% end %>
   </div>
 
+  <%# フリガナフィールド %>
+  <div class="form-control w-full">
+    <label class="label" for="catalog_kana">
+      <span class="label-text font-medium">
+        <%= Catalog.human_attribute_name(:kana) %>
+        <span class="text-error">*</span>
+      </span>
+    </label>
+    <input type="text"
+           id="catalog_kana"
+           name="catalog[kana]"
+           required
+           autocomplete="off"
+           class="input input-bordered w-full <%= 'input-error' if kana_error? %>"
+           placeholder="<%= t('catalogs.new.placeholder.kana') %>">
+    <% creator&.catalog&.errors&.where(:kana)&.each do |error| %>
+      <p class="text-sm text-error mt-1"><%= error.full_message %></p>
+    <% end %>
+  </div>
+
   <%# 通常価格フィールド %>
   <div class="form-control w-full">
     <label class="label" for="catalog_regular_price">

--- a/app/views/components/catalogs/bento_fields/component.rb
+++ b/app/views/components/catalogs/bento_fields/component.rb
@@ -13,6 +13,10 @@ module Catalogs
         creator&.catalog&.errors&.where(:name)&.any? || false
       end
 
+      def kana_error?
+        creator&.catalog&.errors&.where(:kana)&.any? || false
+      end
+
       def regular_price_error?
         creator&.regular_price_record&.errors&.where(:price)&.any? || false
       end

--- a/app/views/components/catalogs/side_menu_fields/component.html.erb
+++ b/app/views/components/catalogs/side_menu_fields/component.html.erb
@@ -20,6 +20,26 @@
     <% end %>
   </div>
 
+  <%# フリガナフィールド %>
+  <div class="form-control w-full">
+    <label class="label" for="catalog_kana">
+      <span class="label-text font-medium">
+        <%= Catalog.human_attribute_name(:kana) %>
+        <span class="text-error">*</span>
+      </span>
+    </label>
+    <input type="text"
+           id="catalog_kana"
+           name="catalog[kana]"
+           required
+           autocomplete="off"
+           class="input input-bordered w-full <%= 'input-error' if kana_error? %>"
+           placeholder="<%= t('catalogs.new.placeholder.side_menu_kana') %>">
+    <% creator&.catalog&.errors&.where(:kana)&.each do |error| %>
+      <p class="text-sm text-error mt-1"><%= error.full_message %></p>
+    <% end %>
+  </div>
+
   <%# 通常価格フィールド %>
   <div class="form-control w-full">
     <label class="label" for="catalog_regular_price">

--- a/app/views/components/catalogs/side_menu_fields/component.rb
+++ b/app/views/components/catalogs/side_menu_fields/component.rb
@@ -13,6 +13,10 @@ module Catalogs
         creator&.catalog&.errors&.where(:name)&.any? || false
       end
 
+      def kana_error?
+        creator&.catalog&.errors&.where(:kana)&.any? || false
+      end
+
       def regular_price_error?
         creator&.regular_price_record&.errors&.where(:price)&.any? || false
       end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -90,6 +90,7 @@ ja:
         updated_at: "更新日時"
       catalog:
         name: "商品名"
+        kana: "フリガナ"
         category: "商品カテゴリ"
         description: "商品説明"
       catalog_price:
@@ -269,7 +270,9 @@ ja:
       submit: "登録する"
       placeholder:
         name: "例: のり弁当"
+        kana: "例: ノリベントウ"
         side_menu_name: "例: 唐揚げ"
+        side_menu_kana: "例: カラアゲ"
         regular_price: "450"
         bundle_price: "100"
       labels:

--- a/db/migrate/20260204142648_add_kana_to_catalogs.rb
+++ b/db/migrate/20260204142648_add_kana_to_catalogs.rb
@@ -1,0 +1,7 @@
+class AddKanaToCatalogs < ActiveRecord::Migration[8.1]
+  def change
+    add_column :catalogs, :kana, :string, null: false, default: "",
+      comment: "商品名のふりがな（カタカナ）"
+    add_index :catalogs, :kana
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_01_31_140604) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_04_142648) do
   create_table "additional_orders", force: :cascade do |t|
     t.integer "catalog_id", null: false
     t.datetime "created_at", null: false
@@ -64,9 +64,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_31_140604) do
     t.integer "category", null: false
     t.datetime "created_at", null: false
     t.text "description", default: "", null: false
+    t.string "kana", default: "", null: false
     t.string "name", null: false
     t.datetime "updated_at", null: false
     t.index ["category"], name: "index_catalogs_on_category"
+    t.index ["kana"], name: "index_catalogs_on_kana"
     t.index ["name"], name: "idx_catalogs_name", unique: true
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -28,53 +28,53 @@ puts "Creating Bento Catalogs..."
 
 bento_data = [
   # 600円
-  { name: "日替わりA", price: 600 },
-  { name: "日替わりA(半ライス)", price: 600 },
-  { name: "日替わりB", price: 600 },
-  { name: "日替わりB(半ライス)", price: 600 },
-  { name: "ジャンバラヤ", price: 600 },
-  { name: "カツどんカレー", price: 600 },
-  { name: "鶏と根菜の黒酢あん", price: 600 },
-  { name: "グリルチキン", price: 600 },
-  { name: "ヘルシー（もろ）", price: 600 },
-  { name: "ヘルシー（生姜焼き）", price: 600 },
-  { name: "ヘルシー（豆腐ハンバーグ）", price: 600 },
-  { name: "トルコライス", price: 600 },
-  { name: "トルコライスカレー", price: 600 },
-  { name: "ビビンバ丼", price: 600 },
-  { name: "牛カルビ丼", price: 600 },
+  { name: "日替わりA", kana: "ヒガワリエー", price: 600 },
+  { name: "日替わりA(半ライス)", kana: "ヒガワリエーハンライス", price: 600 },
+  { name: "日替わりB", kana: "ヒガワリビー", price: 600 },
+  { name: "日替わりB(半ライス)", kana: "ヒガワリビーハンライス", price: 600 },
+  { name: "ジャンバラヤ", kana: "ジャンバラヤ", price: 600 },
+  { name: "カツどんカレー", kana: "カツドンカレー", price: 600 },
+  { name: "鶏と根菜の黒酢あん", kana: "トリトコンサイノクロズアン", price: 600 },
+  { name: "グリルチキン", kana: "グリルチキン", price: 600 },
+  { name: "ヘルシー（もろ）", kana: "ヘルシーモロ", price: 600 },
+  { name: "ヘルシー（生姜焼き）", kana: "ヘルシーショウガヤキ", price: 600 },
+  { name: "ヘルシー（豆腐ハンバーグ）", kana: "ヘルシートウフハンバーグ", price: 600 },
+  { name: "トルコライス", kana: "トルコライス", price: 600 },
+  { name: "トルコライスカレー", kana: "トルコライスカレー", price: 600 },
+  { name: "ビビンバ丼", kana: "ビビンバドン", price: 600 },
+  { name: "牛カルビ丼", kana: "ギュウカルビドン", price: 600 },
   # 550円
-  { name: "炭火焼親子丼", price: 550 },
-  { name: "チキン南蛮丼", price: 550 },
-  { name: "ドライカレー", price: 550 },
-  { name: "きのこロコモコ丼", price: 550 },
-  { name: "和風ロコモコ丼", price: 550 },
-  { name: "サンドイッチセット", price: 550 },
-  { name: "生姜焼き丼", price: 550 },
-  { name: "ゴロゴロ野菜とチキンのカレー", price: 550 },
-  { name: "ロースカツカレー", price: 550 },
-  { name: "ロースかつ丼", price: 550 },
-  { name: "牛丼", price: 550 },
-  { name: "おろしポン酢牛丼", price: 550 },
-  { name: "和風香味ひれかつ丼", price: 550 },
-  { name: "香味たれカツ丼", price: 550 },
-  { name: "ひれかつ丼", price: 550 },
-  { name: "ガパオライス", price: 550 },
-  { name: "麻婆ナス丼", price: 550 },
-  { name: "麻婆豆腐丼", price: 550 },
-  { name: "中華丼", price: 550 },
-  { name: "タコライス", price: 550 },
-  { name: "カレーオムライス", price: 550 },
+  { name: "炭火焼親子丼", kana: "スミビヤキオヤコドン", price: 550 },
+  { name: "チキン南蛮丼", kana: "チキンナンバンドン", price: 550 },
+  { name: "ドライカレー", kana: "ドライカレー", price: 550 },
+  { name: "きのこロコモコ丼", kana: "キノコロコモコドン", price: 550 },
+  { name: "和風ロコモコ丼", kana: "ワフウロコモコドン", price: 550 },
+  { name: "サンドイッチセット", kana: "サンドイッチセット", price: 550 },
+  { name: "生姜焼き丼", kana: "ショウガヤキドン", price: 550 },
+  { name: "ゴロゴロ野菜とチキンのカレー", kana: "ゴロゴロヤサイトチキンノカレー", price: 550 },
+  { name: "ロースカツカレー", kana: "ロースカツカレー", price: 550 },
+  { name: "ロースかつ丼", kana: "ロースカツドン", price: 550 },
+  { name: "牛丼", kana: "ギュウドン", price: 550 },
+  { name: "おろしポン酢牛丼", kana: "オロシポンズギュウドン", price: 550 },
+  { name: "和風香味ひれかつ丼", kana: "ワフウコウミヒレカツドン", price: 550 },
+  { name: "香味たれカツ丼", kana: "コウミタレカツドン", price: 550 },
+  { name: "ひれかつ丼", kana: "ヒレカツドン", price: 550 },
+  { name: "ガパオライス", kana: "ガパオライス", price: 550 },
+  { name: "麻婆ナス丼", kana: "マーボーナスドン", price: 550 },
+  { name: "麻婆豆腐丼", kana: "マーボードウフドン", price: 550 },
+  { name: "中華丼", kana: "チュウカドン", price: 550 },
+  { name: "タコライス", kana: "タコライス", price: 550 },
+  { name: "カレーオムライス", kana: "カレーオムライス", price: 550 },
   # 500円
-  { name: "のり弁当", price: 500 },
-  { name: "唐揚げポン酢丼", price: 500 },
-  { name: "天丼", price: 500 }
+  { name: "のり弁当", kana: "ノリベントウ", price: 500 },
+  { name: "唐揚げポン酢丼", kana: "カラアゲポンズドン", price: 500 },
+  { name: "天丼", kana: "テンドン", price: 500 }
 ]
 
 bento_data.each do |data|
   next if Catalog.exists?(name: data[:name])
 
-  Catalogs::BentoCreator.new(name: data[:name], regular_price: data[:price]).create!
+  Catalogs::BentoCreator.new(name: data[:name], kana: data[:kana], regular_price: data[:price]).create!
   puts "  Bento: #{data[:name]} (#{data[:price]}円)"
 end
 
@@ -82,7 +82,7 @@ end
 puts "Creating Side Menu Catalogs..."
 
 side_menu_data = [
-  { name: "サラダ", regular_price: 250, bundle_price: 150 }
+  { name: "サラダ", kana: "サラダ", regular_price: 250, bundle_price: 150 }
 ]
 
 side_menu_data.each do |data|
@@ -90,6 +90,7 @@ side_menu_data.each do |data|
 
   Catalogs::SideMenuCreator.new(
     name: data[:name],
+    kana: data[:kana],
     regular_price: data[:regular_price],
     bundle_price: data[:bundle_price]
   ).create!

--- a/test/controllers/catalogs_controller_test.rb
+++ b/test/controllers/catalogs_controller_test.rb
@@ -44,6 +44,7 @@ class CatalogsControllerTest < ActionDispatch::IntegrationTest
         post catalogs_path, params: {
           catalog: {
             name: "新規弁当",
+            kana: "シンキベントウ",
             category: "bento",
             description: "新商品の説明",
             regular_price: 450
@@ -99,6 +100,7 @@ class CatalogsControllerTest < ActionDispatch::IntegrationTest
         post catalogs_path, params: {
           catalog: {
             name: "従業員作成弁当",
+            kana: "ジュウギョウインサクセイベントウ",
             category: "bento",
             description: "従業員が作成",
             regular_price: 400
@@ -176,7 +178,7 @@ class CatalogsControllerTest < ActionDispatch::IntegrationTest
   test "create with blank name renders new with unprocessable_entity" do
     login_as_employee(@employee)
     assert_no_difference("Catalog.count") do
-      post catalogs_path, params: { catalog: { name: "", category: "bento", regular_price: 450 } }, as: :turbo_stream
+      post catalogs_path, params: { catalog: { name: "", kana: "テスト", category: "bento", regular_price: 450 } }, as: :turbo_stream
     end
     assert_response :unprocessable_entity
   end
@@ -207,6 +209,7 @@ class CatalogsControllerTest < ActionDispatch::IntegrationTest
       post catalogs_path, params: {
         catalog: {
           name: "テスト弁当",
+          kana: "テストベントウ",
           category: "invalid_category",
           regular_price: 450
         }

--- a/test/fixtures/catalogs.yml
+++ b/test/fixtures/catalogs.yml
@@ -3,25 +3,30 @@
 
 daily_bento_a:
   name: "日替わり弁当A"
+  kana: "ヒガワリベントウエー"
   category: 0
   description: "本日のおすすめ弁当"
 
 daily_bento_b:
   name: "日替わり弁当B"
+  kana: "ヒガワリベントウビー"
   category: 0
   description: "ヘルシー弁当"
 
 salad:
   name: "サラダ"
+  kana: "サラダ"
   category: 1
   description: "新鮮野菜のサラダ"
 
 discontinued_bento:
   name: "販売終了弁当"
+  kana: "ハンバイシュウリョウベントウ"
   category: 0
   description: "提供終了した弁当"
 
 miso_soup:
   name: "味噌汁"
+  kana: "ミソシル"
   category: 1
   description: "日替わり味噌汁"

--- a/test/models/catalog_test.rb
+++ b/test/models/catalog_test.rb
@@ -6,19 +6,42 @@ class CatalogTest < ActiveSupport::TestCase
   # ===== バリデーションテスト =====
 
   test "name は必須" do
-    catalog = Catalog.new(name: nil, category: :bento)
+    catalog = Catalog.new(name: nil, kana: "テストベントウ", category: :bento)
     assert_not catalog.valid?
     assert_includes catalog.errors[:name], "を入力してください"
   end
 
   test "category は必須" do
-    catalog = Catalog.new(name: "テスト弁当", category: nil)
+    catalog = Catalog.new(name: "テスト弁当", kana: "テストベントウ", category: nil)
     assert_not catalog.valid?
     assert_includes catalog.errors[:category], "を入力してください"
   end
 
+  test "kana は必須" do
+    catalog = Catalog.new(name: "テスト弁当", kana: nil, category: :bento)
+    assert_not catalog.valid?
+    assert_includes catalog.errors[:kana], "を入力してください"
+  end
+
+  test "kana はカタカナのみ許可" do
+    catalog = Catalog.new(name: "テスト弁当", kana: "てすとべんとう", category: :bento)
+    assert_not catalog.valid?
+    assert_includes catalog.errors[:kana], "はカタカナで入力してください"
+  end
+
+  test "kana に漢字を含むとバリデーションエラー" do
+    catalog = Catalog.new(name: "テスト弁当", kana: "テスト弁当", category: :bento)
+    assert_not catalog.valid?
+    assert_includes catalog.errors[:kana], "はカタカナで入力してください"
+  end
+
+  test "kana に長音符（ー）を含んでも有効" do
+    catalog = Catalog.new(name: "カレー", kana: "カレー", category: :bento)
+    assert catalog.valid?, "長音符を含む kana は有効であるべき: #{catalog.errors.full_messages.join(', ')}"
+  end
+
   test "有効な属性で作成できる" do
-    catalog = Catalog.new(name: "新規テスト弁当", category: :bento, description: "本日のおすすめ弁当")
+    catalog = Catalog.new(name: "新規テスト弁当", kana: "シンキテストベントウ", category: :bento, description: "本日のおすすめ弁当")
     assert catalog.valid?, "有効な属性で Catalog を作成できるべき: #{catalog.errors.full_messages.join(', ')}"
   end
 
@@ -38,16 +61,16 @@ class CatalogTest < ActiveSupport::TestCase
   # ===== Enum スコープテスト =====
 
   test "bento スコープは bento カテゴリのみ取得" do
-    bento = Catalog.create!(name: "テスト弁当", category: :bento)
-    side_menu = Catalog.create!(name: "テストサラダ", category: :side_menu)
+    bento = Catalog.create!(name: "テスト弁当", kana: "テストベントウ", category: :bento)
+    side_menu = Catalog.create!(name: "テストサラダ", kana: "テストサラダ", category: :side_menu)
 
     assert_includes Catalog.bento, bento
     assert_not_includes Catalog.bento, side_menu
   end
 
   test "side_menu スコープは side_menu カテゴリのみ取得" do
-    bento = Catalog.create!(name: "テスト弁当B", category: :bento)
-    side_menu = Catalog.create!(name: "テストサラダB", category: :side_menu)
+    bento = Catalog.create!(name: "テスト弁当B", kana: "テストベントウビー", category: :bento)
+    side_menu = Catalog.create!(name: "テストサラダB", kana: "テストサラダビー", category: :side_menu)
 
     assert_includes Catalog.side_menu, side_menu
     assert_not_includes Catalog.side_menu, bento
@@ -56,13 +79,13 @@ class CatalogTest < ActiveSupport::TestCase
   # ===== Enum 更新メソッドテスト =====
 
   test "bento! で category を bento に変更" do
-    catalog = Catalog.create!(name: "変更テスト商品", category: :side_menu)
+    catalog = Catalog.create!(name: "変更テスト商品", kana: "ヘンコウテストショウヒン", category: :side_menu)
     catalog.bento!
     assert catalog.bento?
   end
 
   test "side_menu! で category を side_menu に変更" do
-    catalog = Catalog.create!(name: "変更テスト商品2", category: :bento)
+    catalog = Catalog.create!(name: "変更テスト商品2", kana: "ヘンコウテストショウヒンニ", category: :bento)
     catalog.side_menu!
     assert catalog.side_menu?
   end
@@ -77,17 +100,17 @@ class CatalogTest < ActiveSupport::TestCase
   # ===== ユニーク制約テスト（Task 4.5 追加） =====
 
   test "name のユニーク制約（大文字小文字を区別しない）" do
-    Catalog.create!(name: "テスト弁当X", category: :bento)
+    Catalog.create!(name: "テスト弁当X", kana: "テストベントウエックス", category: :bento)
 
-    duplicate = Catalog.new(name: "テスト弁当X", category: :bento)
+    duplicate = Catalog.new(name: "テスト弁当X", kana: "テストベントウエックス", category: :bento)
     assert_not duplicate.valid?
     assert_includes duplicate.errors[:name], "はすでに存在します"
   end
 
   test "name のユニーク制約は大文字小文字を区別しない" do
-    Catalog.create!(name: "Test Bento", category: :bento)
+    Catalog.create!(name: "Test Bento", kana: "テストベントウ", category: :bento)
 
-    duplicate = Catalog.new(name: "test bento", category: :bento)
+    duplicate = Catalog.new(name: "test bento", kana: "テストベントウ", category: :bento)
     assert_not duplicate.valid?
     assert_includes duplicate.errors[:name], "はすでに存在します"
   end
@@ -120,7 +143,7 @@ class CatalogTest < ActiveSupport::TestCase
   end
 
   test "active_pricing_rules は現在有効なルールのみ取得" do
-    catalog = Catalog.create!(name: "active_pricing_rules テスト", category: :side_menu)
+    catalog = Catalog.create!(name: "active_pricing_rules テスト", kana: "アクティブプライシングルールステスト", category: :side_menu)
 
     # 過去のルール（有効期限切れ）
     past_rule = CatalogPricingRule.create!(
@@ -173,7 +196,7 @@ class CatalogTest < ActiveSupport::TestCase
   # ===== ビジネスロジックメソッドテスト（Task 4.5 追加） =====
 
   test "price_by_kind は指定した kind の現在有効な価格を取得" do
-    catalog = Catalog.create!(name: "price_by_kind テスト", category: :side_menu)
+    catalog = Catalog.create!(name: "price_by_kind テスト", kana: "プライスバイカインドテスト", category: :side_menu)
 
     regular_price = CatalogPrice.create!(
       catalog: catalog,
@@ -196,7 +219,7 @@ class CatalogTest < ActiveSupport::TestCase
   end
 
   test "price_by_kind は有効な価格がない場合 nil を返す" do
-    catalog = Catalog.create!(name: "価格なしテスト2", category: :bento)
+    catalog = Catalog.create!(name: "価格なしテスト2", kana: "カカクナシテストニ", category: :bento)
     assert_nil catalog.price_by_kind(:regular)
   end
 
@@ -219,8 +242,8 @@ class CatalogTest < ActiveSupport::TestCase
   # ===== available スコープテスト =====
 
   test "available スコープは提供終了していない商品のみ取得" do
-    available_catalog = Catalog.create!(name: "販売中弁当", category: :bento)
-    discontinued_catalog = Catalog.create!(name: "終了弁当", category: :bento)
+    available_catalog = Catalog.create!(name: "販売中弁当", kana: "ハンバイチュウベントウ", category: :bento)
+    discontinued_catalog = Catalog.create!(name: "終了弁当", kana: "シュウリョウベントウ", category: :bento)
 
     CatalogDiscontinuation.create!(
       catalog: discontinued_catalog,
@@ -233,9 +256,9 @@ class CatalogTest < ActiveSupport::TestCase
   end
 
   test "available スコープは他のスコープとチェーン可能" do
-    available_bento = Catalog.create!(name: "販売中弁当C", category: :bento)
-    available_side = Catalog.create!(name: "販売中サイド", category: :side_menu)
-    discontinued_bento = Catalog.create!(name: "終了弁当C", category: :bento)
+    available_bento = Catalog.create!(name: "販売中弁当C", kana: "ハンバイチュウベントウシー", category: :bento)
+    available_side = Catalog.create!(name: "販売中サイド", kana: "ハンバイチュウサイド", category: :side_menu)
+    discontinued_bento = Catalog.create!(name: "終了弁当C", kana: "シュウリョウベントウシー", category: :bento)
 
     CatalogDiscontinuation.create!(
       catalog: discontinued_bento,
@@ -251,31 +274,32 @@ class CatalogTest < ActiveSupport::TestCase
 
   # ===== display_order スコープテスト =====
 
-  test "display_order は販売中を先に、同じ状態内では name 昇順" do
-    available_b = Catalog.create!(name: "B弁当販売中", category: :bento)
-    available_a = Catalog.create!(name: "A弁当販売中", category: :bento)
-    discontinued_b = Catalog.create!(name: "B弁当終了", category: :bento)
-    discontinued_a = Catalog.create!(name: "A弁当終了", category: :bento)
+  test "display_order は販売中を先に、同じ状態内では kana 昇順" do
+    available_b = Catalog.create!(name: "B弁当販売中", kana: "ビーベントウハンバイチュウ", category: :bento)
+    available_a = Catalog.create!(name: "A弁当販売中", kana: "エーベントウハンバイチュウ", category: :bento)
+    discontinued_b = Catalog.create!(name: "B弁当終了", kana: "ビーベントウシュウリョウ", category: :bento)
+    discontinued_a = Catalog.create!(name: "A弁当終了", kana: "エーベントウシュウリョウ", category: :bento)
 
     CatalogDiscontinuation.create!(catalog: discontinued_b, discontinued_at: Time.current, reason: "終了")
     CatalogDiscontinuation.create!(catalog: discontinued_a, discontinued_at: Time.current, reason: "終了")
 
     result = Catalog.where(id: [ available_a, available_b, discontinued_a, discontinued_b ]).display_order.to_a
 
-    # 販売中が先（A弁当販売中, B弁当販売中）、販売停止が後（A弁当終了, B弁当終了）の name 順
+    # 販売中が先（エー, ビー）、販売停止が後（エー, ビー）の kana 順
     assert_equal [ available_a, available_b, discontinued_a, discontinued_b ], result
   end
 
   # ===== category_order スコープテスト =====
 
-  test "category_order は弁当を先、サイドメニューを後に名前順で返す" do
-    bento_b = Catalog.create!(name: "B弁当", category: :bento)
-    bento_a = Catalog.create!(name: "A弁当", category: :bento)
-    side_b = Catalog.create!(name: "Bサイド", category: :side_menu)
-    side_a = Catalog.create!(name: "Aサイド", category: :side_menu)
+  test "category_order は弁当を先、サイドメニューを後に kana 順で返す" do
+    bento_b = Catalog.create!(name: "B弁当", kana: "ビーベントウ", category: :bento)
+    bento_a = Catalog.create!(name: "A弁当", kana: "エーベントウ", category: :bento)
+    side_b = Catalog.create!(name: "Bサイド", kana: "ビーサイド", category: :side_menu)
+    side_a = Catalog.create!(name: "Aサイド", kana: "エーサイド", category: :side_menu)
 
     result = Catalog.where(id: [ bento_a, bento_b, side_a, side_b ]).category_order.to_a
 
+    # 弁当（エー, ビー）、サイドメニュー（エー, ビー）の kana 順
     assert_equal [ bento_a, bento_b, side_a, side_b ], result
   end
 

--- a/test/models/catalogs/bento_creator_test.rb
+++ b/test/models/catalogs/bento_creator_test.rb
@@ -8,6 +8,7 @@ class Catalogs::BentoCreatorTest < ActiveSupport::TestCase
   test "弁当を作成できること" do
     creator = Catalogs::BentoCreator.new(
       name: "のり弁当",
+      kana: "ノリベントウ",
       regular_price: 450
     )
 
@@ -24,6 +25,7 @@ class Catalogs::BentoCreatorTest < ActiveSupport::TestCase
   test "弁当作成時に pricing_rule は作成されないこと" do
     creator = Catalogs::BentoCreator.new(
       name: "のり弁当",
+      kana: "ノリベントウ",
       regular_price: 450
     )
 
@@ -35,6 +37,7 @@ class Catalogs::BentoCreatorTest < ActiveSupport::TestCase
   test "description を設定できること" do
     creator = Catalogs::BentoCreator.new(
       name: "のり弁当",
+      kana: "ノリベントウ",
       regular_price: 450,
       description: "海苔と鮭フレークをのせた弁当"
     )
@@ -46,6 +49,7 @@ class Catalogs::BentoCreatorTest < ActiveSupport::TestCase
   test "description を省略した場合は空文字になること" do
     creator = Catalogs::BentoCreator.new(
       name: "のり弁当",
+      kana: "ノリベントウ",
       regular_price: 450
     )
 
@@ -58,6 +62,7 @@ class Catalogs::BentoCreatorTest < ActiveSupport::TestCase
   test "valid? は有効なデータで true を返すこと" do
     creator = Catalogs::BentoCreator.new(
       name: "テスト弁当",
+      kana: "テストベントウ",
       regular_price: 450
     )
 
@@ -78,6 +83,7 @@ class Catalogs::BentoCreatorTest < ActiveSupport::TestCase
   test "valid? は regular_price が 0 以下の場合に false を返すこと" do
     creator = Catalogs::BentoCreator.new(
       name: "テスト弁当",
+      kana: "テストベントウ",
       regular_price: 0
     )
 
@@ -86,10 +92,11 @@ class Catalogs::BentoCreatorTest < ActiveSupport::TestCase
   end
 
   test "valid? は重複する name の場合に false を返すこと" do
-    Catalog.create!(name: "既存弁当", category: :bento)
+    Catalog.create!(name: "既存弁当", kana: "キゾンベントウ", category: :bento)
 
     creator = Catalogs::BentoCreator.new(
       name: "既存弁当",
+      kana: "キゾンベントウ",
       regular_price: 450
     )
 
@@ -113,6 +120,7 @@ class Catalogs::BentoCreatorTest < ActiveSupport::TestCase
   test "regular_price が0以下の場合はモデルのバリデーションエラーになること" do
     creator = Catalogs::BentoCreator.new(
       name: "テスト弁当",
+      kana: "テストベントウ",
       regular_price: 0
     )
 
@@ -149,6 +157,7 @@ class Catalogs::BentoCreatorTest < ActiveSupport::TestCase
   test "create メソッドは成功時にカタログを返すこと" do
     creator = Catalogs::BentoCreator.new(
       name: "テスト弁当",
+      kana: "テストベントウ",
       regular_price: 450
     )
 

--- a/test/models/catalogs/side_menu_creator_test.rb
+++ b/test/models/catalogs/side_menu_creator_test.rb
@@ -8,6 +8,7 @@ class Catalogs::SideMenuCreatorTest < ActiveSupport::TestCase
   test "サイドメニューを通常価格のみで作成できること" do
     creator = Catalogs::SideMenuCreator.new(
       name: "唐揚げ",
+      kana: "カラアゲ",
       regular_price: 150
     )
 
@@ -23,6 +24,7 @@ class Catalogs::SideMenuCreatorTest < ActiveSupport::TestCase
   test "通常価格のみの場合 pricing_rule は作成されないこと" do
     creator = Catalogs::SideMenuCreator.new(
       name: "唐揚げ",
+      kana: "カラアゲ",
       regular_price: 150
     )
 
@@ -36,6 +38,7 @@ class Catalogs::SideMenuCreatorTest < ActiveSupport::TestCase
   test "サイドメニューをセット価格付きで作成できること" do
     creator = Catalogs::SideMenuCreator.new(
       name: "唐揚げ",
+      kana: "カラアゲ",
       regular_price: 150,
       bundle_price: 100
     )
@@ -68,6 +71,7 @@ class Catalogs::SideMenuCreatorTest < ActiveSupport::TestCase
   test "description を設定できること" do
     creator = Catalogs::SideMenuCreator.new(
       name: "唐揚げ",
+      kana: "カラアゲ",
       regular_price: 150,
       description: "ジューシーな鶏の唐揚げ"
     )
@@ -79,6 +83,7 @@ class Catalogs::SideMenuCreatorTest < ActiveSupport::TestCase
   test "description を省略した場合は空文字になること" do
     creator = Catalogs::SideMenuCreator.new(
       name: "唐揚げ",
+      kana: "カラアゲ",
       regular_price: 150
     )
 
@@ -91,6 +96,7 @@ class Catalogs::SideMenuCreatorTest < ActiveSupport::TestCase
   test "valid? は有効なデータで true を返すこと" do
     creator = Catalogs::SideMenuCreator.new(
       name: "テストサイドメニュー",
+      kana: "テストサイドメニュー",
       regular_price: 150
     )
 
@@ -101,6 +107,7 @@ class Catalogs::SideMenuCreatorTest < ActiveSupport::TestCase
   test "valid? はセット価格付きで有効なデータでも true を返すこと" do
     creator = Catalogs::SideMenuCreator.new(
       name: "テストサイドメニュー",
+      kana: "テストサイドメニュー",
       regular_price: 150,
       bundle_price: 100
     )
@@ -122,6 +129,7 @@ class Catalogs::SideMenuCreatorTest < ActiveSupport::TestCase
   test "valid? は regular_price が 0 以下の場合に false を返すこと" do
     creator = Catalogs::SideMenuCreator.new(
       name: "テストサイドメニュー",
+      kana: "テストサイドメニュー",
       regular_price: 0
     )
 
@@ -132,6 +140,7 @@ class Catalogs::SideMenuCreatorTest < ActiveSupport::TestCase
   test "valid? は bundle_price が 0 以下の場合に false を返すこと" do
     creator = Catalogs::SideMenuCreator.new(
       name: "テストサイドメニュー",
+      kana: "テストサイドメニュー",
       regular_price: 150,
       bundle_price: 0
     )
@@ -141,10 +150,11 @@ class Catalogs::SideMenuCreatorTest < ActiveSupport::TestCase
   end
 
   test "valid? は重複する name の場合に false を返すこと" do
-    Catalog.create!(name: "既存サイドメニュー", category: :side_menu)
+    Catalog.create!(name: "既存サイドメニュー", kana: "キゾンサイドメニュー", category: :side_menu)
 
     creator = Catalogs::SideMenuCreator.new(
       name: "既存サイドメニュー",
+      kana: "キゾンサイドメニュー",
       regular_price: 150
     )
 
@@ -168,6 +178,7 @@ class Catalogs::SideMenuCreatorTest < ActiveSupport::TestCase
   test "regular_price が0以下の場合はモデルのバリデーションエラーになること" do
     creator = Catalogs::SideMenuCreator.new(
       name: "テストサイドメニュー",
+      kana: "テストサイドメニュー",
       regular_price: 0
     )
 
@@ -179,6 +190,7 @@ class Catalogs::SideMenuCreatorTest < ActiveSupport::TestCase
   test "bundle_price が0以下の場合はモデルのバリデーションエラーになること" do
     creator = Catalogs::SideMenuCreator.new(
       name: "テストサイドメニュー",
+      kana: "テストサイドメニュー",
       regular_price: 150,
       bundle_price: 0
     )
@@ -216,6 +228,7 @@ class Catalogs::SideMenuCreatorTest < ActiveSupport::TestCase
   test "create メソッドは成功時にカタログを返すこと" do
     creator = Catalogs::SideMenuCreator.new(
       name: "テストサイドメニュー",
+      kana: "テストサイドメニュー",
       regular_price: 150
     )
 


### PR DESCRIPTION
## Summary

- 商品の並び順をふりがな順に変更し、ユーザーの認知負荷を下げる
- Catalog モデルに kana カラムを追加（カタカナのみ、必須）
- display_order / category_order スコープを kana 順にソート
- 新規登録・編集フォームにふりがな入力欄を追加

## Test plan

- [ ] `rails db:migrate` でマイグレーション実行
- [ ] `rails test` で全テスト通過を確認
- [ ] 管理画面で商品の新規登録・編集画面にふりがなフィールドが表示されることを確認
- [ ] 既存商品の編集画面でふりがなを入力・保存できることを確認
- [ ] POS画面で商品がふりがな順に並ぶことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * カタログ作成フォーム全体に「フリガナ」入力欄を追加しました
  * フリガナはカタカナ形式での入力が必須となります

* **改善**
  * カタログの表示順序をフリガナベースで並べ替えるよう変更しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->