### PR TITLE
fix: bulk_recreateのTOCTOU競合状態を修正

### DIFF
--- a/app/models/daily_inventory.rb
+++ b/app/models/daily_inventory.rb
@@ -21,9 +21,9 @@ class DailyInventory < ApplicationRecord
   end
 
   def self.bulk_recreate(location:, items:)
-    return :sales_already_started if sales_started?(location: location)
-
     transaction do
+      return :sales_already_started if sales_started?(location: location)
+
       delete_by(location: location, inventory_date: Date.current)
       bulk_create(location: location, items: items)
     end


### PR DESCRIPTION
## Summary
- `DailyInventory.bulk_recreate`の`sales_started?`チェックをトランザクション内に移動
- チェックと`delete_by`の間に販売（`decrement_stock!`）が割り込み、販売済みレコードが削除されるデータ整合性の問題を防止

## Test plan
- [x] `bin/rails test test/models/daily_inventory_test.rb` — 全テストパス
- [x] `bin/rails test test/controllers/pos/locations/daily_inventories/corrections_controller_test.rb` — 全テストパス
- [x] 既存テスト「販売が開始された在庫は再登録できない」が`:sales_already_started`パスを検証
- [x] 既存テスト「登録済みの在庫を削除してから再作成できる」が正常パスを検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 販売開始前に在庫数を修正できる「在庫修正」機能を追加しました。既に在庫登録済みの場合、販売画面に修正バナーが表示され、登録内容を再登録できます。販売開始後の修正はできません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->