### PR TITLE
fix: POS画面の顧客区分ラベルを「関係者/一般」に変更

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -193,8 +193,8 @@ ja:
         completed: "完了"
         voided: "取消"
       customer_type:
-        staff: "職員"
-        citizen: "市民"
+        staff: "関係者"
+        citizen: "一般"
 
   custom_errors:
     controllers:


### PR DESCRIPTION
## Summary
- POS画面の顧客区分ラベルを「職員/市民」から「関係者/一般」に変更
- 販売員がPOSレジ操作時、お客さんに見える区分表記がソフトな表現になる
- i18nキー管理のため `config/locales/ja.yml` の1箇所変更で全画面に反映

## Test plan
- [x] `bin/rails test` 全417テスト通過（0 failures, 0 errors）
- [ ] ブラウザで http://localhost:3000/pos/locations/3/sales/new を開き、ボタン表記が「関係者」「一般」になっていることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ローカライゼーション**
  * 日本語のユーザーインターフェイス表記が更新されました。販売関連の顧客種別の表示テキストが改善され、より適切な日本語表現に変更しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->