### PR TITLE
fix: モバイルのプルトゥリフレッシュを無効化

### DIFF
--- a/app/frontend/stylesheets/application.tailwind.css
+++ b/app/frontend/stylesheets/application.tailwind.css
@@ -72,3 +72,8 @@ turbo-frame[busy] {
 .safe-area-pb {
   padding-bottom: max(1rem, env(safe-area-inset-bottom));
 }
+
+/* モバイル: プルトゥリフレッシュ（下スクロールリロード）を無効化 */
+body {
+  overscroll-behavior-y: none;
+}


### PR DESCRIPTION
## Summary
- スマホでレジ画面操作中に画面を下にスワイプするとブラウザのプルトゥリフレッシュが発動し、入力中のデータが初期化される問題を修正
- `body` に CSS `overscroll-behavior-y: none` を適用してプルトゥリフレッシュを無効化
- 全モダンブラウザ対応済みの標準プロパティを使用

## Test plan
- [ ] `bin/dev` でローカルサーバーを起動
- [ ] スマホ実機 or Chrome DevTools のモバイルエミュレーションでレジ画面を開く
- [ ] 画面最上部で下方向にスワイプし、リロードが発生しないことを確認
- [ ] 通常のスクロール操作に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **スタイル**
  * モバイルデバイスでのプルトゥーリフレッシュ時のバウンス動作を無効化しました。これによりモバイルユーザーのスクロール体験が向上します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->