### PR TITLE
Upgrade minitest 5.x to 6.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,8 +55,8 @@ gem "sentry-ruby"
 gem "sentry-rails"
 
 group :development, :test do
-  # Pin minitest to 5.x for Rails 8.1.1 compatibility (minitest 6.x has known issues)
-  gem "minitest", "~> 5.25"
+  # minitest 6.x (minitest/mock is extracted to minitest-mock gem)
+  gem "minitest", "~> 6.0"
 
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"
@@ -85,4 +85,5 @@ end
 group :test do
   gem "shoulda-matchers"
   gem "minitest-matchers_vaccine"
+  gem "minitest-mock"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,9 +180,12 @@ GEM
     mini_magick (5.3.1)
       logger
     mini_mime (1.1.5)
-    minitest (5.27.0)
+    minitest (6.0.2)
+      drb (~> 2.0)
+      prism (~> 1.5)
     minitest-matchers_vaccine (1.1.0)
       minitest (>= 5.0, < 7.0)
+    minitest-mock (5.27.0)
     msgpack (1.8.0)
     mutex_m (0.3.0)
     net-imap (0.6.2)
@@ -447,8 +450,9 @@ DEPENDENCIES
   image_processing (~> 1.2)
   kamal
   lookbook
-  minitest (~> 5.25)
+  minitest (~> 6.0)
   minitest-matchers_vaccine
+  minitest-mock
   propshaft
   puma (>= 5.0)
   rails (~> 8.1.2)


### PR DESCRIPTION
## Summary

- minitest を 5.27.0 → 6.0.2 にメジャーアップグレード
- minitest 6.0 で削除された `minitest/mock` の代替として `minitest-mock` gem を追加
- PR #94 (dependabot) の手動対応版

## 破壊的変更の影響確認

| 変更 | 影響 |
|---|---|
| `minitest/mock` 削除 → `minitest-mock` gem | `minitest-mock` gem 追加で対応済み |
| `assert_equal(nil, ...)` 禁止 | 影響なし（既に `assert_nil` 使用済み） |
| `assert_send` 削除 | 影響なし（使用箇所なし） |
| `MiniTest` 互換名前空間削除 | 影響なし |
| Object への spec expectations 削除 | 影響なし |

## Test plan

- [x] `bin/rails test` — 417 runs, 0 failures（既存の Vite 関連エラー 7 件のみ、main と同一）
- [x] `bin/rubocop -a` — 237 files, no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * テスト実行環境の依存関係を更新しました。最新のテストフレームワークバージョンに対応し、開発環境を改善します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->