### PR TITLE
feat: rubocop-minitest を導入

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,22 @@
 # Omakase Ruby styling for Rails
 inherit_gem: { rubocop-rails-omakase: rubocop.yml }
 
+plugins:
+  - rubocop-minitest
+
+AllCops:
+  NewCops: enable
+
+# Rails のテスト慣習として 1 メソッド内の複数 assertion は許容する
+Minitest/MultipleAssertions:
+  Enabled: false
+
+# refute_* vs assert_not_* の方針: rubocop-minitest 寄せ (refute_* を採用)
+# omakase の Rails/RefuteMethods は `assert_not_*` を推奨するが、本プロジェクトでは
+# Minitest/Refute* 系 cop と方向が衝突するため明示的に無効化する。
+Rails/RefuteMethods:
+  Enabled: false
+
 # Overwrite or add rules to create your own house style
 #
 # # Use `[a, [b, c]]` not `[ a, [ b, c ] ]`

--- a/Gemfile
+++ b/Gemfile
@@ -72,6 +72,9 @@ group :development, :test do
 
   # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
   gem "rubocop-rails-omakase", require: false
+
+  # Minitest-specific cops for RuboCop [https://github.com/rubocop/rubocop-minitest]
+  gem "rubocop-minitest", require: false
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -322,6 +322,10 @@ GEM
     rubocop-ast (1.49.0)
       parser (>= 3.3.7.2)
       prism (~> 1.7)
+    rubocop-minitest (0.39.1)
+      lint_roller (~> 1.1)
+      rubocop (>= 1.75.0, < 2.0)
+      rubocop-ast (>= 1.38.0, < 2.0)
     rubocop-performance (1.26.1)
       lint_roller (~> 1.1)
       rubocop (>= 1.75.0, < 2.0)
@@ -460,6 +464,7 @@ DEPENDENCIES
   rails-i18n (~> 8.0)
   reactionview
   rodauth-rails
+  rubocop-minitest
   rubocop-rails-omakase
   sentry-rails
   sentry-ruby

--- a/test/components/location_card_component_test.rb
+++ b/test/components/location_card_component_test.rb
@@ -23,7 +23,7 @@ class LocationCardComponentTest < ViewComponent::TestCase
   def test_inactive_location_renders_status_badge
     result = render_inline(LocationCard::Component.new(location: @inactive_location))
 
-    assert result.css(".badge.badge-soft.badge-error").present?
+    assert_predicate result.css(".badge.badge-soft.badge-error"), :present?
     assert_includes result.to_html, "取引停止"
   end
 
@@ -31,22 +31,24 @@ class LocationCardComponentTest < ViewComponent::TestCase
     result = render_inline(LocationCard::Component.new(location: @active_location))
 
     link = result.css("a.card").first
-    assert link.present?
+
+    assert_predicate link, :present?
     assert_equal "/locations/1", link["href"]
   end
 
   def test_renders_card_structure
     result = render_inline(LocationCard::Component.new(location: @active_location))
 
-    assert result.css(".card").present?
-    assert result.css(".card-body").present?
-    assert result.css(".card-title").present?
+    assert_predicate result.css(".card"), :present?
+    assert_predicate result.css(".card-body"), :present?
+    assert_predicate result.css(".card-title"), :present?
   end
 
   def test_card_has_hover_effect
     result = render_inline(LocationCard::Component.new(location: @active_location))
 
     link = result.css("a.card").first
+
     assert_includes link["class"], "hover:shadow-md"
   end
 end

--- a/test/components/locations/list_component_test.rb
+++ b/test/components/locations/list_component_test.rb
@@ -11,7 +11,7 @@ class Locations::ListComponentTest < ViewComponent::TestCase
   def test_renders_grid_with_locations
     result = render_inline(Locations::List::Component.new(locations: [ @location1, @location2 ]))
 
-    assert result.css(".grid").present?
+    assert_predicate result.css(".grid"), :present?
     assert_includes result.to_html, @location1.name
     assert_includes result.to_html, @location2.name
   end
@@ -33,6 +33,7 @@ class Locations::ListComponentTest < ViewComponent::TestCase
     result = render_inline(Locations::List::Component.new(locations: [ @location1 ]))
 
     grid = result.css(".grid").first
+
     assert_includes grid["class"], "grid-cols-1"
     assert_includes grid["class"], "md:grid-cols-2"
     assert_includes grid["class"], "lg:grid-cols-3"
@@ -41,6 +42,6 @@ class Locations::ListComponentTest < ViewComponent::TestCase
   def test_empty_state_has_icon
     result = render_inline(Locations::List::Component.new(locations: []))
 
-    assert result.css(".icon").present?
+    assert_predicate result.css(".icon"), :present?
   end
 end

--- a/test/components/locations/sales_chart_component_test.rb
+++ b/test/components/locations/sales_chart_component_test.rb
@@ -14,7 +14,7 @@ class Locations::SalesChartComponentTest < ViewComponent::TestCase
 
     result = render_inline(Locations::SalesChart::Component.new(location:))
 
-    assert result.css("[id^='chart-']").present?
+    assert_predicate result.css("[id^='chart-']"), :present?
   end
 
   test "chart_data に職員・市民の2系列と直近1ヶ月分の全日データが含まれる" do
@@ -29,6 +29,7 @@ class Locations::SalesChartComponentTest < ViewComponent::TestCase
     assert_equal "市民", data[1][:name]
 
     expected_days = (1.month.ago.to_date..Date.current).count
+
     assert_equal expected_days, data[0][:data].size
     assert_equal expected_days, data[1][:data].size
   end

--- a/test/components/locations/show_component_test.rb
+++ b/test/components/locations/show_component_test.rb
@@ -27,14 +27,14 @@ class Locations::ShowComponentTest < ViewComponent::TestCase
   def test_renders_location_name_in_header
     result = render_inline(Locations::Show::Component.new(location: @active_location))
 
-    assert result.css("h1").present?
+    assert_predicate result.css("h1"), :present?
     assert_includes result.to_html, @active_location.name
   end
 
   def test_renders_status_badge
     result = render_inline(Locations::Show::Component.new(location: @active_location))
 
-    assert result.css(".badge").present?
+    assert_predicate result.css(".badge"), :present?
   end
 
   def test_renders_edit_link
@@ -42,7 +42,8 @@ class Locations::ShowComponentTest < ViewComponent::TestCase
 
     # 編集リンクは基本情報セクション内にあり、edit へのリンク（Turbo Frame で処理）
     edit_link = result.css("a[href='/locations/1/edit']").first
-    assert edit_link.present?
+
+    assert_predicate edit_link, :present?
     assert_includes edit_link["class"], "btn"
     assert_includes edit_link["class"], "btn-ghost"
   end
@@ -51,21 +52,23 @@ class Locations::ShowComponentTest < ViewComponent::TestCase
     result = render_inline(Locations::Show::Component.new(location: @active_location))
 
     back_link = result.css("nav a[href='/locations']").first
-    assert back_link.present?
+
+    assert_predicate back_link, :present?
     assert_includes result.to_html, "販売先一覧へ戻る"
   end
 
   def test_renders_basic_info_card
     result = render_inline(Locations::Show::Component.new(location: @active_location))
 
-    assert result.css(".card").present?
-    assert result.css(".card-body").present?
+    assert_predicate result.css(".card"), :present?
+    assert_predicate result.css(".card-body"), :present?
   end
 
   def test_inactive_location_has_opacity
     result = render_inline(Locations::Show::Component.new(location: @inactive_location))
 
     card = result.css("section.card").first
+
     assert_includes card["class"], "opacity-75"
   end
 
@@ -78,14 +81,14 @@ class Locations::ShowComponentTest < ViewComponent::TestCase
   def test_has_accessible_section_headings
     result = render_inline(Locations::Show::Component.new(location: @active_location))
 
-    assert result.css("section[aria-labelledby='basic-info-heading']").present?
-    assert result.css("section[aria-labelledby='sales-history-heading']").present?
+    assert_predicate result.css("section[aria-labelledby='basic-info-heading']"), :present?
+    assert_predicate result.css("section[aria-labelledby='sales-history-heading']"), :present?
   end
 
   def test_renders_location_icon_in_header
     result = render_inline(Locations::Show::Component.new(location: @active_location))
 
-    assert result.css("header .icon").present?
+    assert_predicate result.css("header .icon"), :present?
   end
 
   def test_renders_created_at_and_updated_at
@@ -107,7 +110,7 @@ class Locations::ShowComponentTest < ViewComponent::TestCase
 
     result = render_inline(Locations::Show::Component.new(location:))
 
-    assert result.css("[id^='chart-']").present?
+    assert_predicate result.css("[id^='chart-']"), :present?
     assert_not_includes result.to_html, "販売履歴はありません"
   end
 end

--- a/test/components/navbar_component_test.rb
+++ b/test/components/navbar_component_test.rb
@@ -6,14 +6,14 @@ class NavbarComponentTest < ViewComponent::TestCase
   def test_renders_navbar
     result = render_inline(Navbar::Component.new)
 
-    assert result.css(".navbar").present?
+    assert_predicate result.css(".navbar"), :present?
   end
 
   def test_renders_mobile_menu_toggle
     result = render_inline(Navbar::Component.new)
 
-    assert result.css("label[for='main-drawer']").present?
-    assert result.css(".icon").present?
+    assert_predicate result.css("label[for='main-drawer']"), :present?
+    assert_predicate result.css(".icon"), :present?
   end
 
   def test_renders_app_title
@@ -32,6 +32,6 @@ class NavbarComponentTest < ViewComponent::TestCase
   def test_uses_custom_drawer_id
     result = render_inline(Navbar::Component.new(drawer_id: "custom-drawer"))
 
-    assert result.css("label[for='custom-drawer']").present?
+    assert_predicate result.css("label[for='custom-drawer']"), :present?
   end
 end

--- a/test/components/page_header_component_test.rb
+++ b/test/components/page_header_component_test.rb
@@ -6,21 +6,21 @@ class PageHeaderComponentTest < ViewComponent::TestCase
   def test_renders_title
     result = render_inline(PageHeader::Component.new(title: "テストタイトル"))
 
-    assert result.css("h1").present?
+    assert_predicate result.css("h1"), :present?
     assert_includes result.to_html, "テストタイトル"
   end
 
   def test_renders_new_button_when_path_provided
     result = render_inline(PageHeader::Component.new(title: "テスト", new_path: "/test/new"))
 
-    assert result.css("a.btn.btn-neutral").present?
+    assert_predicate result.css("a.btn.btn-neutral"), :present?
     assert_includes result.to_html, "新規登録"
   end
 
   def test_hides_new_button_when_path_not_provided
     result = render_inline(PageHeader::Component.new(title: "テスト"))
 
-    assert result.css("a.btn").blank?
+    assert_predicate result.css("a.btn"), :blank?
   end
 
   def test_renders_custom_new_label
@@ -36,7 +36,7 @@ class PageHeaderComponentTest < ViewComponent::TestCase
   def test_renders_plus_icon
     result = render_inline(PageHeader::Component.new(title: "テスト", new_path: "/test/new"))
 
-    assert result.css(".icon").present?
+    assert_predicate result.css(".icon"), :present?
   end
 
   def test_renders_link_with_turbo_stream_when_enabled
@@ -46,7 +46,7 @@ class PageHeaderComponentTest < ViewComponent::TestCase
       turbo_stream: true
     ))
 
-    assert result.css("a.btn.btn-neutral").present?
+    assert_predicate result.css("a.btn.btn-neutral"), :present?
     assert_includes result.to_html, "data-turbo-stream=\"true\""
   end
 
@@ -56,7 +56,7 @@ class PageHeaderComponentTest < ViewComponent::TestCase
       new_path: "/test/new"
     ))
 
-    assert result.css("a.btn.btn-neutral").present?
+    assert_predicate result.css("a.btn.btn-neutral"), :present?
     refute_includes result.to_html, "data-turbo-stream"
   end
 end

--- a/test/components/sidebar_component_test.rb
+++ b/test/components/sidebar_component_test.rb
@@ -6,7 +6,7 @@ class SidebarComponentTest < ViewComponent::TestCase
   def test_renders_sidebar
     result = render_inline(Sidebar::Component.new(current_path: "/"))
 
-    assert result.css("aside").present?
+    assert_predicate result.css("aside"), :present?
     assert_includes result.to_html, "Bento Manager"
   end
 
@@ -23,6 +23,7 @@ class SidebarComponentTest < ViewComponent::TestCase
     result = render_inline(Sidebar::Component.new(current_path: "/"))
 
     active_link = result.css("a.active")
+
     assert_not active_link.present?, "Should not highlight on root path (only /pos/* paths)"
   end
 
@@ -30,7 +31,8 @@ class SidebarComponentTest < ViewComponent::TestCase
     result = render_inline(Sidebar::Component.new(current_path: "/pos/locations"))
 
     active_link = result.css("a.active")
-    assert active_link.present?
+
+    assert_predicate active_link, :present?
     assert_includes active_link.to_html, "販売"
   end
 
@@ -38,7 +40,8 @@ class SidebarComponentTest < ViewComponent::TestCase
     result = render_inline(Sidebar::Component.new(current_path: "/locations"))
 
     active_link = result.css("a.active")
-    assert active_link.present?
+
+    assert_predicate active_link, :present?
     assert_includes active_link.to_html, "配達場所"
   end
 
@@ -46,14 +49,15 @@ class SidebarComponentTest < ViewComponent::TestCase
     result = render_inline(Sidebar::Component.new(current_path: "/catalogs/new"))
 
     active_link = result.css("a.active")
-    assert active_link.present?
+
+    assert_predicate active_link, :present?
     assert_includes active_link.to_html, "カタログ"
   end
 
   def test_renders_menu_icons
     result = render_inline(Sidebar::Component.new(current_path: "/"))
 
-    assert result.css(".icon").count >= 4
+    assert_operator result.css(".icon").count, :>=, 4
   end
 
   def test_renders_footer_with_copyright

--- a/test/components/status_badge_component_test.rb
+++ b/test/components/status_badge_component_test.rb
@@ -6,21 +6,21 @@ class StatusBadgeComponentTest < ViewComponent::TestCase
   def test_renders_active_badge
     result = render_inline(StatusBadge::Component.new(status: :active))
 
-    assert result.css(".badge.badge-success").present?
+    assert_predicate result.css(".badge.badge-success"), :present?
     assert_includes result.to_html, "取引中"
   end
 
   def test_renders_inactive_badge
     result = render_inline(StatusBadge::Component.new(status: :inactive))
 
-    assert result.css(".badge.badge-error").present?
+    assert_predicate result.css(".badge.badge-error"), :present?
     assert_includes result.to_html, "取引停止"
   end
 
   def test_accepts_string_status
     result = render_inline(StatusBadge::Component.new(status: "active"))
 
-    assert result.css(".badge.badge-success").present?
+    assert_predicate result.css(".badge.badge-success"), :present?
   end
 
   def test_renders_with_custom_model

--- a/test/controllers/catalog_prices_controller_test.rb
+++ b/test/controllers/catalog_prices_controller_test.rb
@@ -19,12 +19,14 @@ class CatalogPricesControllerTest < ActionDispatch::IntegrationTest
   test "admin can access edit for existing price" do
     login_as_employee(@employee)
     get edit_catalog_catalog_price_path(@catalog, :regular), as: :turbo_stream
+
     assert_response :success
   end
 
   test "admin can access edit for non-existing price" do
     login_as_employee(@employee)
     get edit_catalog_catalog_price_path(@catalog_without_bundle, :bundle), as: :turbo_stream
+
     assert_response :success
   end
 
@@ -50,9 +52,11 @@ class CatalogPricesControllerTest < ActionDispatch::IntegrationTest
     assert_equal original_count + 1, CatalogPrice.count
 
     @catalog_price.reload
+
     assert_not_nil @catalog_price.effective_until
 
     new_price = @catalog.price_by_kind(:regular)
+
     assert_equal 600, new_price.price
     assert_nil new_price.effective_until
   end
@@ -64,6 +68,7 @@ class CatalogPricesControllerTest < ActionDispatch::IntegrationTest
   test "employee can access edit" do
     login_as_employee(@employee)
     get edit_catalog_catalog_price_path(@catalog, :regular), as: :turbo_stream
+
     assert_response :success
   end
 
@@ -86,6 +91,7 @@ class CatalogPricesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
 
     new_price = @catalog.price_by_kind(:regular)
+
     assert_equal 580, new_price.price
   end
 
@@ -95,6 +101,7 @@ class CatalogPricesControllerTest < ActionDispatch::IntegrationTest
 
   test "unauthenticated user is redirected to login on edit" do
     get edit_catalog_catalog_price_path(@catalog, :regular), as: :turbo_stream
+
     assert_redirected_to "/employee/login"
   end
 
@@ -103,8 +110,10 @@ class CatalogPricesControllerTest < ActionDispatch::IntegrationTest
     patch catalog_catalog_price_path(@catalog, :regular), params: {
       catalog_price: { price: 999 }
     }, as: :turbo_stream
+
     assert_redirected_to "/employee/login"
     @catalog_price.reload
+
     assert_equal original_price, @catalog_price.price
   end
 
@@ -115,6 +124,7 @@ class CatalogPricesControllerTest < ActionDispatch::IntegrationTest
   test "returns not found for invalid kind on edit" do
     login_as_employee(@employee)
     get edit_catalog_catalog_price_path(@catalog, :invalid), as: :turbo_stream
+
     assert_response :not_found
   end
 
@@ -123,6 +133,7 @@ class CatalogPricesControllerTest < ActionDispatch::IntegrationTest
     patch catalog_catalog_price_path(@catalog, :invalid), params: {
       catalog_price: { price: 500 }
     }, as: :turbo_stream
+
     assert_response :not_found
   end
 
@@ -151,6 +162,7 @@ class CatalogPricesControllerTest < ActionDispatch::IntegrationTest
     assert_response :unprocessable_entity
     assert_equal original_count, CatalogPrice.count
     @catalog_price.reload
+
     assert_nil @catalog_price.effective_until
   end
 end

--- a/test/controllers/catalogs/discontinuations_controller_test.rb
+++ b/test/controllers/catalogs/discontinuations_controller_test.rb
@@ -23,6 +23,7 @@ module Catalogs
     test "admin can access new (discontinue confirmation modal)" do
       login_as_employee(@employee)
       get new_catalog_discontinuation_path(@catalog), as: :turbo_stream
+
       assert_response :success
     end
 
@@ -35,7 +36,8 @@ module Catalogs
       end
       assert_redirected_to catalog_path(@catalog)
       @catalog.reload
-      assert @catalog.discontinued?
+
+      assert_predicate @catalog, :discontinued?
     end
 
     # ============================================================
@@ -45,6 +47,7 @@ module Catalogs
     test "employee can access new (discontinue confirmation modal)" do
       login_as_employee(@employee)
       get new_catalog_discontinuation_path(@catalog), as: :turbo_stream
+
       assert_response :success
     end
 
@@ -57,7 +60,8 @@ module Catalogs
       end
       assert_redirected_to catalog_path(@catalog)
       @catalog.reload
-      assert @catalog.discontinued?
+
+      assert_predicate @catalog, :discontinued?
     end
 
     # ============================================================
@@ -66,6 +70,7 @@ module Catalogs
 
     test "unauthenticated user is redirected to login on new" do
       get new_catalog_discontinuation_path(@catalog)
+
       assert_redirected_to "/employee/login"
     end
 
@@ -75,6 +80,7 @@ module Catalogs
       end
       assert_redirected_to "/employee/login"
       @catalog.reload
+
       assert_not @catalog.discontinued?
     end
 
@@ -94,18 +100,22 @@ module Catalogs
     test "create with reason saves the reason" do
       login_as_employee(@employee)
       post catalog_discontinuation_path(@catalog), params: { reason: "季節終了のため" }
+
       assert_redirected_to catalog_path(@catalog)
       @catalog.reload
-      assert @catalog.discontinued?
+
+      assert_predicate @catalog, :discontinued?
       assert_equal "季節終了のため", @catalog.discontinuation.reason
     end
 
     test "create without reason uses default reason" do
       login_as_employee(@employee)
       post catalog_discontinuation_path(@catalog)
+
       assert_redirected_to catalog_path(@catalog)
       @catalog.reload
-      assert @catalog.discontinued?
+
+      assert_predicate @catalog, :discontinued?
       assert_equal I18n.t("catalogs.discontinuations.default_reason"), @catalog.discontinuation.reason
     end
   end

--- a/test/controllers/catalogs_controller_test.rb
+++ b/test/controllers/catalogs_controller_test.rb
@@ -22,18 +22,21 @@ class CatalogsControllerTest < ActionDispatch::IntegrationTest
   test "admin can access index" do
     login_as_employee(@employee)
     get catalogs_path
+
     assert_response :success
   end
 
   test "admin can access show" do
     login_as_employee(@employee)
     get catalog_path(@catalog)
+
     assert_response :success
   end
 
   test "admin can access new" do
     login_as_employee(@employee)
     get new_catalog_path, as: :turbo_stream
+
     assert_response :success
   end
 
@@ -58,6 +61,7 @@ class CatalogsControllerTest < ActionDispatch::IntegrationTest
   test "admin can access edit" do
     login_as_employee(@employee)
     get edit_catalog_path(@catalog)
+
     assert_response :success
   end
 
@@ -66,8 +70,10 @@ class CatalogsControllerTest < ActionDispatch::IntegrationTest
     patch catalog_path(@catalog), params: {
       catalog: { name: "更新された弁当名" }
     }, as: :turbo_stream
+
     assert_response :success
     @catalog.reload
+
     assert_equal "更新された弁当名", @catalog.name
   end
 
@@ -78,18 +84,21 @@ class CatalogsControllerTest < ActionDispatch::IntegrationTest
   test "employee can access index" do
     login_as_employee(@employee)
     get catalogs_path
+
     assert_response :success
   end
 
   test "employee can access show" do
     login_as_employee(@employee)
     get catalog_path(@catalog)
+
     assert_response :success
   end
 
   test "employee can access new" do
     login_as_employee(@employee)
     get new_catalog_path, as: :turbo_stream
+
     assert_response :success
   end
 
@@ -114,6 +123,7 @@ class CatalogsControllerTest < ActionDispatch::IntegrationTest
   test "employee can access edit" do
     login_as_employee(@employee)
     get edit_catalog_path(@catalog)
+
     assert_response :success
   end
 
@@ -122,8 +132,10 @@ class CatalogsControllerTest < ActionDispatch::IntegrationTest
     patch catalog_path(@catalog), params: {
       catalog: { name: "従業員更新弁当名" }
     }, as: :turbo_stream
+
     assert_response :success
     @catalog.reload
+
     assert_equal "従業員更新弁当名", @catalog.name
   end
 
@@ -133,16 +145,19 @@ class CatalogsControllerTest < ActionDispatch::IntegrationTest
 
   test "unauthenticated user is redirected to login on index" do
     get catalogs_path
+
     assert_redirected_to "/employee/login"
   end
 
   test "unauthenticated user is redirected to login on show" do
     get catalog_path(@catalog)
+
     assert_redirected_to "/employee/login"
   end
 
   test "unauthenticated user is redirected to login on new" do
     get new_catalog_path
+
     assert_redirected_to "/employee/login"
   end
 
@@ -160,6 +175,7 @@ class CatalogsControllerTest < ActionDispatch::IntegrationTest
 
   test "unauthenticated user is redirected to login on edit" do
     get edit_catalog_path(@catalog)
+
     assert_redirected_to "/employee/login"
   end
 
@@ -167,6 +183,7 @@ class CatalogsControllerTest < ActionDispatch::IntegrationTest
     patch catalog_path(@catalog), params: {
       catalog: { name: "不正な更新" }
     }
+
     assert_redirected_to "/employee/login"
   end
 
@@ -187,8 +204,10 @@ class CatalogsControllerTest < ActionDispatch::IntegrationTest
     login_as_employee(@employee)
     original_name = @catalog.name
     patch catalog_path(@catalog), params: { catalog: { name: "" } }, as: :turbo_stream
+
     assert_response :unprocessable_entity
     @catalog.reload
+
     assert_equal original_name, @catalog.name
   end
 
@@ -199,6 +218,7 @@ class CatalogsControllerTest < ActionDispatch::IntegrationTest
   test "new with invalid category returns unprocessable_entity" do
     login_as_employee(@employee)
     get new_catalog_path, params: { category: "invalid_category" }
+
     assert_response :unprocessable_entity
     assert_equal({ "error" => I18n.t("catalogs.errors.invalid_category") }, response.parsed_body)
   end

--- a/test/controllers/discounts_controller_test.rb
+++ b/test/controllers/discounts_controller_test.rb
@@ -18,18 +18,21 @@ class DiscountsControllerTest < ActionDispatch::IntegrationTest
   test "admin can access index" do
     login_as_employee(@employee)
     get discounts_path
+
     assert_response :success
   end
 
   test "admin can access show" do
     login_as_employee(@employee)
     get discount_path(@discount)
+
     assert_response :success
   end
 
   test "admin can access new" do
     login_as_employee(@employee)
     get new_discount_path, as: :turbo_stream
+
     assert_response :success
   end
 
@@ -55,6 +58,7 @@ class DiscountsControllerTest < ActionDispatch::IntegrationTest
   test "admin can access edit" do
     login_as_employee(@employee)
     get edit_discount_path(@discount)
+
     assert_response :success
   end
 
@@ -66,8 +70,10 @@ class DiscountsControllerTest < ActionDispatch::IntegrationTest
     patch discount_path(@discount), params: {
       discount: { valid_from: new_valid_from, valid_until: new_valid_until }
     }, as: :turbo_stream
+
     assert_response :success
     @discount.reload
+
     assert_equal new_valid_from, @discount.valid_from
     assert_equal new_valid_until, @discount.valid_until
   end
@@ -78,8 +84,10 @@ class DiscountsControllerTest < ActionDispatch::IntegrationTest
     patch discount_path(@discount), params: {
       discount: { name: "更新されたクーポン名" }
     }, as: :turbo_stream
+
     assert_response :success
     @discount.reload
+
     assert_equal original_name, @discount.name
   end
 
@@ -94,8 +102,10 @@ class DiscountsControllerTest < ActionDispatch::IntegrationTest
         }
       }
     }, as: :turbo_stream
+
     assert_response :success
     @discount.discountable.reload
+
     assert_equal original_amount, @discount.discountable.amount_per_unit
   end
 
@@ -106,18 +116,21 @@ class DiscountsControllerTest < ActionDispatch::IntegrationTest
   test "employee can access index" do
     login_as_employee(@employee)
     get discounts_path
+
     assert_response :success
   end
 
   test "employee can access show" do
     login_as_employee(@employee)
     get discount_path(@discount)
+
     assert_response :success
   end
 
   test "employee can access new" do
     login_as_employee(@employee)
     get new_discount_path, as: :turbo_stream
+
     assert_response :success
   end
 
@@ -142,6 +155,7 @@ class DiscountsControllerTest < ActionDispatch::IntegrationTest
   test "employee can access edit" do
     login_as_employee(@employee)
     get edit_discount_path(@discount)
+
     assert_response :success
   end
 
@@ -152,8 +166,10 @@ class DiscountsControllerTest < ActionDispatch::IntegrationTest
     patch discount_path(@discount), params: {
       discount: { valid_from: new_valid_from }
     }, as: :turbo_stream
+
     assert_response :success
     @discount.reload
+
     assert_equal new_valid_from, @discount.valid_from
   end
 
@@ -163,16 +179,19 @@ class DiscountsControllerTest < ActionDispatch::IntegrationTest
 
   test "unauthenticated user is redirected to login on index" do
     get discounts_path
+
     assert_redirected_to "/employee/login"
   end
 
   test "unauthenticated user is redirected to login on show" do
     get discount_path(@discount)
+
     assert_redirected_to "/employee/login"
   end
 
   test "unauthenticated user is redirected to login on new" do
     get new_discount_path
+
     assert_redirected_to "/employee/login"
   end
 
@@ -190,6 +209,7 @@ class DiscountsControllerTest < ActionDispatch::IntegrationTest
 
   test "unauthenticated user is redirected to login on edit" do
     get edit_discount_path(@discount)
+
     assert_redirected_to "/employee/login"
   end
 
@@ -197,6 +217,7 @@ class DiscountsControllerTest < ActionDispatch::IntegrationTest
     patch discount_path(@discount), params: {
       discount: { name: "不正な更新" }
     }
+
     assert_redirected_to "/employee/login"
   end
 
@@ -227,8 +248,10 @@ class DiscountsControllerTest < ActionDispatch::IntegrationTest
     patch discount_path(@discount), params: {
       discount: { valid_from: Date.current + 1.month, valid_until: Date.current }
     }, as: :turbo_stream
+
     assert_response :unprocessable_entity
     @discount.reload
+
     assert_equal original_valid_from, @discount.valid_from
   end
 end

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -18,18 +18,21 @@ class LocationsControllerTest < ActionDispatch::IntegrationTest
   test "admin can access index" do
     login_as_employee(@employee)
     get locations_path
+
     assert_response :success
   end
 
   test "admin can access show" do
     login_as_employee(@employee)
     get location_path(@location)
+
     assert_response :success
   end
 
   test "admin can access new" do
     login_as_employee(@employee)
     get new_location_path, as: :turbo_stream
+
     assert_response :success
   end
 
@@ -48,6 +51,7 @@ class LocationsControllerTest < ActionDispatch::IntegrationTest
   test "admin can access edit" do
     login_as_employee(@employee)
     get edit_location_path(@location)
+
     assert_response :success
   end
 
@@ -56,8 +60,10 @@ class LocationsControllerTest < ActionDispatch::IntegrationTest
     patch location_path(@location), params: {
       location: { name: "更新された販売先名" }
     }, as: :turbo_stream
+
     assert_response :success
     @location.reload
+
     assert_equal "更新された販売先名", @location.name
   end
 
@@ -68,18 +74,21 @@ class LocationsControllerTest < ActionDispatch::IntegrationTest
   test "employee can access index" do
     login_as_employee(@employee)
     get locations_path
+
     assert_response :success
   end
 
   test "employee can access show" do
     login_as_employee(@employee)
     get location_path(@location)
+
     assert_response :success
   end
 
   test "employee can access new" do
     login_as_employee(@employee)
     get new_location_path, as: :turbo_stream
+
     assert_response :success
   end
 
@@ -98,6 +107,7 @@ class LocationsControllerTest < ActionDispatch::IntegrationTest
   test "employee can access edit" do
     login_as_employee(@employee)
     get edit_location_path(@location)
+
     assert_response :success
   end
 
@@ -106,8 +116,10 @@ class LocationsControllerTest < ActionDispatch::IntegrationTest
     patch location_path(@location), params: {
       location: { name: "従業員更新販売先名" }
     }, as: :turbo_stream
+
     assert_response :success
     @location.reload
+
     assert_equal "従業員更新販売先名", @location.name
   end
 
@@ -117,16 +129,19 @@ class LocationsControllerTest < ActionDispatch::IntegrationTest
 
   test "unauthenticated user is redirected to login on index" do
     get locations_path
+
     assert_redirected_to "/employee/login"
   end
 
   test "unauthenticated user is redirected to login on show" do
     get location_path(@location)
+
     assert_redirected_to "/employee/login"
   end
 
   test "unauthenticated user is redirected to login on new" do
     get new_location_path
+
     assert_redirected_to "/employee/login"
   end
 
@@ -143,6 +158,7 @@ class LocationsControllerTest < ActionDispatch::IntegrationTest
 
   test "unauthenticated user is redirected to login on edit" do
     get edit_location_path(@location)
+
     assert_redirected_to "/employee/login"
   end
 
@@ -150,6 +166,7 @@ class LocationsControllerTest < ActionDispatch::IntegrationTest
     patch location_path(@location), params: {
       location: { name: "不正な更新" }
     }
+
     assert_redirected_to "/employee/login"
   end
 
@@ -170,8 +187,10 @@ class LocationsControllerTest < ActionDispatch::IntegrationTest
     login_as_employee(@employee)
     original_name = @location.name
     patch location_path(@location), params: { location: { name: "" } }, as: :turbo_stream
+
     assert_response :unprocessable_entity
     @location.reload
+
     assert_equal original_name, @location.name
   end
 end

--- a/test/controllers/pos/locations/additional_orders/form_states_controller_test.rb
+++ b/test/controllers/pos/locations/additional_orders/form_states_controller_test.rb
@@ -16,6 +16,7 @@ module Pos
 
         test "unauthenticated user is redirected to login" do
           post pos_location_additional_orders_form_state_path(@location)
+
           assert_redirected_to "/employee/login"
         end
 

--- a/test/controllers/pos/locations/additional_orders_controller_test.rb
+++ b/test/controllers/pos/locations/additional_orders_controller_test.rb
@@ -21,17 +21,20 @@ module Pos
       test "admin can access index page" do
         login_as_employee(@employee)
         get pos_location_additional_orders_path(@location)
+
         assert_response :success
       end
 
       test "employee can access index page" do
         login_as_employee(@employee)
         get pos_location_additional_orders_path(@location)
+
         assert_response :success
       end
 
       test "unauthenticated user is redirected to login on index" do
         get pos_location_additional_orders_path(@location)
+
         assert_redirected_to "/employee/login"
       end
 
@@ -39,12 +42,14 @@ module Pos
         login_as_employee(@employee)
         inactive_location = locations(:prefectural_office)
         get pos_location_additional_orders_path(inactive_location)
+
         assert_response :not_found
       end
 
       test "index page displays inventory summary" do
         login_as_employee(@employee)
         get pos_location_additional_orders_path(@location)
+
         assert_response :success
         assert_select "span", text: @bento_a.name
       end
@@ -52,6 +57,7 @@ module Pos
       test "index page displays help messages" do
         login_as_employee(@employee)
         get pos_location_additional_orders_path(@location)
+
         assert_response :success
         assert_select ".alert-info", /LINE/
         assert_select ".alert-warning", /取り消し/
@@ -60,6 +66,7 @@ module Pos
       test "index page displays link to new order page" do
         login_as_employee(@employee)
         get pos_location_additional_orders_path(@location)
+
         assert_response :success
         assert_select "a[href='#{new_pos_location_additional_order_path(@location)}']"
       end
@@ -71,17 +78,20 @@ module Pos
       test "admin can access new page" do
         login_as_employee(@employee)
         get new_pos_location_additional_order_path(@location)
+
         assert_response :success
       end
 
       test "employee can access new page" do
         login_as_employee(@employee)
         get new_pos_location_additional_order_path(@location)
+
         assert_response :success
       end
 
       test "unauthenticated user is redirected to login on new" do
         get new_pos_location_additional_order_path(@location)
+
         assert_redirected_to "/employee/login"
       end
 
@@ -89,12 +99,14 @@ module Pos
         login_as_employee(@employee)
         inactive_location = locations(:prefectural_office)
         get new_pos_location_additional_order_path(inactive_location)
+
         assert_response :not_found
       end
 
       test "new page displays bento inventory items" do
         login_as_employee(@employee)
         get new_pos_location_additional_order_path(@location)
+
         assert_response :success
         assert_select "#order-item-#{@bento_a.id}"
       end
@@ -102,8 +114,10 @@ module Pos
       test "new page does not display side menu items in order form" do
         login_as_employee(@employee)
         get new_pos_location_additional_order_path(@location)
+
         assert_response :success
         salad = catalogs(:salad)
+
         assert_select "#order-item-#{salad.id}", count: 0
       end
 
@@ -136,6 +150,7 @@ module Pos
 
         assert_redirected_to pos_location_additional_orders_path(@location)
         follow_redirect!
+
         assert_select ".alert-success", /2件の追加発注を記録しました/
       end
 
@@ -197,6 +212,7 @@ module Pos
                }
 
           order = AdditionalOrder.last
+
           assert_in_delta Time.current, order.order_at, 1.second
         end
       end
@@ -212,6 +228,7 @@ module Pos
              }
 
         order = AdditionalOrder.last
+
         assert_equal @employee, order.employee
       end
 
@@ -233,6 +250,7 @@ module Pos
 
       test "unauthenticated user is redirected to login on create" do
         post pos_location_additional_orders_path(@location)
+
         assert_redirected_to "/employee/login"
       end
     end

--- a/test/controllers/pos/locations/daily_inventories/corrections_controller_test.rb
+++ b/test/controllers/pos/locations/daily_inventories/corrections_controller_test.rb
@@ -28,6 +28,7 @@ module Pos
           )
 
           get new_pos_location_daily_inventories_correction_path(@location)
+
           assert_response :success
           assert_match 'value="10"', response.body
           assert_match 'value="5"', response.body
@@ -52,6 +53,7 @@ module Pos
           assert_redirected_to new_pos_location_sale_path(@location)
 
           recreated = DailyInventory.find_by(location: @location, catalog: @bento_a, inventory_date: Date.current)
+
           assert_equal 20, recreated.stock
           assert_equal 0, recreated.lock_version
         end
@@ -79,6 +81,7 @@ module Pos
           login_as_employee(@employee)
 
           get new_pos_location_daily_inventories_correction_path(@location)
+
           assert_redirected_to new_pos_location_daily_inventory_path(@location)
         end
       end

--- a/test/controllers/pos/locations/daily_inventories_controller_test.rb
+++ b/test/controllers/pos/locations/daily_inventories_controller_test.rb
@@ -22,18 +22,21 @@ module Pos
       test "admin can access new page" do
         login_as_employee(@employee)
         get new_pos_location_daily_inventory_path(@location)
+
         assert_response :success
       end
 
       test "employee can access new page" do
         login_as_employee(@employee)
         get new_pos_location_daily_inventory_path(@location)
+
         assert_response :success
       end
 
       test "new page displays available bento catalogs" do
         login_as_employee(@employee)
         get new_pos_location_daily_inventory_path(@location)
+
         assert_response :success
         assert_select "span", text: @bento_a.name
       end
@@ -41,6 +44,7 @@ module Pos
       test "new page displays available side menu catalogs" do
         login_as_employee(@employee)
         get new_pos_location_daily_inventory_path(@location)
+
         assert_response :success
         assert_select "span", text: @salad.name
       end
@@ -55,6 +59,7 @@ module Pos
         )
 
         get new_pos_location_daily_inventory_path(@location)
+
         assert_response :success
         assert_select "span", text: discontinued_bento.name, count: 0
       end
@@ -62,12 +67,14 @@ module Pos
       test "new page shows submit button disabled by default" do
         login_as_employee(@employee)
         get new_pos_location_daily_inventory_path(@location)
+
         assert_response :success
         assert_select "button[type='submit'][disabled]"
       end
 
       test "unauthenticated user is redirected to login on new" do
         get new_pos_location_daily_inventory_path(@location)
+
         assert_redirected_to "/employee/login"
       end
 
@@ -75,6 +82,7 @@ module Pos
         login_as_employee(@employee)
         inactive_location = locations(:prefectural_office)
         get new_pos_location_daily_inventory_path(inactive_location)
+
         assert_response :not_found
       end
 
@@ -151,6 +159,7 @@ module Pos
 
         assert_redirected_to new_pos_location_sale_path(@location)
         follow_redirect!
+
         assert_select ".alert-success", /2種類/
       end
 
@@ -195,6 +204,7 @@ module Pos
              }
 
         inventory = DailyInventory.last
+
         assert_equal Date.current, inventory.inventory_date
       end
 
@@ -209,6 +219,7 @@ module Pos
              }
 
         inventory = DailyInventory.last
+
         assert_equal 0, inventory.reserved_stock
       end
 
@@ -223,6 +234,7 @@ module Pos
              }
 
         inventory = DailyInventory.last
+
         assert_equal 25, inventory.stock
       end
 
@@ -240,6 +252,7 @@ module Pos
 
         assert_redirected_to new_pos_location_sale_path(@location)
         follow_redirect!
+
         assert_select ".alert-success", /1種類/
       end
 
@@ -259,6 +272,7 @@ module Pos
 
         assert_redirected_to new_pos_location_sale_path(@location)
         follow_redirect!
+
         assert_select ".alert-success", /3種類/
       end
 
@@ -274,11 +288,13 @@ module Pos
 
         assert_redirected_to new_pos_location_sale_path(@location)
         follow_redirect!
+
         assert_select ".alert-success", text: /商品を登録しました/
       end
 
       test "unauthenticated user is redirected to login on create" do
         post pos_location_daily_inventories_path(@location)
+
         assert_redirected_to "/employee/login"
       end
 
@@ -290,6 +306,7 @@ module Pos
         )
 
         get new_pos_location_daily_inventory_path(@location)
+
         assert_redirected_to new_pos_location_daily_inventories_correction_path(@location)
       end
     end

--- a/test/controllers/pos/locations/sales/form_states_controller_test.rb
+++ b/test/controllers/pos/locations/sales/form_states_controller_test.rb
@@ -21,6 +21,7 @@ module Pos
 
         test "unauthenticated user is redirected to login" do
           post pos_location_sales_form_state_path(@location)
+
           assert_redirected_to "/employee/login"
         end
 

--- a/test/controllers/pos/locations/sales_controller_test.rb
+++ b/test/controllers/pos/locations/sales_controller_test.rb
@@ -21,17 +21,20 @@ module Pos
       test "admin can access new page" do
         login_as_employee(@employee)
         get new_pos_location_sale_path(@location)
+
         assert_response :success
       end
 
       test "employee can access new page" do
         login_as_employee(@employee)
         get new_pos_location_sale_path(@location)
+
         assert_response :success
       end
 
       test "unauthenticated user is redirected to login on new" do
         get new_pos_location_sale_path(@location)
+
         assert_redirected_to "/employee/login"
       end
 
@@ -39,6 +42,7 @@ module Pos
         login_as_employee(@employee)
         location = Location.create!(name: "在庫なし店舗", status: :active)
         get new_pos_location_sale_path(location)
+
         assert_redirected_to new_pos_location_daily_inventory_path(location)
       end
 
@@ -46,12 +50,14 @@ module Pos
         login_as_employee(@employee)
         inactive_location = locations(:prefectural_office)
         get new_pos_location_sale_path(inactive_location)
+
         assert_response :not_found
       end
 
       test "new returns 404 for non-existent location" do
         login_as_employee(@employee)
         get new_pos_location_sale_path(location_id: 999999)
+
         assert_response :not_found
       end
 
@@ -76,6 +82,7 @@ module Pos
 
         assert_redirected_to new_pos_location_sale_path(@location)
         follow_redirect!
+
         assert_select ".alert-success", /販売を記録しました/
       end
 
@@ -142,6 +149,7 @@ module Pos
              }
 
         sale = Sale.last
+
         assert_equal 550, sale.total_amount
         assert_equal 500, sale.final_amount
         assert_equal 1, sale.sale_discounts.count
@@ -197,6 +205,7 @@ module Pos
 
       test "unauthenticated user is redirected to login on create" do
         post pos_location_sales_path(@location)
+
         assert_redirected_to "/employee/login"
       end
     end

--- a/test/controllers/pos/locations_controller_test.rb
+++ b/test/controllers/pos/locations_controller_test.rb
@@ -19,12 +19,14 @@ module Pos
     test "admin can access index" do
       login_as_employee(@employee)
       get pos_locations_path
+
       assert_response :success
     end
 
     test "index displays only active locations for admin" do
       login_as_employee(@employee)
       get pos_locations_path
+
       assert_response :success
       assert_select "h2", text: @active_location.name
       assert_select "h2", text: @inactive_location.name, count: 0
@@ -37,12 +39,14 @@ module Pos
     test "employee can access index" do
       login_as_employee(@employee)
       get pos_locations_path
+
       assert_response :success
     end
 
     test "index displays only active locations for employee" do
       login_as_employee(@employee)
       get pos_locations_path
+
       assert_response :success
       assert_select "h2", text: @active_location.name
       assert_select "h2", text: @inactive_location.name, count: 0
@@ -54,6 +58,7 @@ module Pos
 
     test "unauthenticated user is redirected to login on index" do
       get pos_locations_path
+
       assert_redirected_to "/employee/login"
     end
 
@@ -65,6 +70,7 @@ module Pos
       login_as_employee(@employee)
       Location.active.update_all(status: :inactive)
       get pos_locations_path
+
       assert_response :success
       assert_select "a[href=?]", locations_path
     end
@@ -79,6 +85,7 @@ module Pos
       no_inventory_location = Location.create!(name: "在庫なし販売先", status: :active)
 
       get pos_locations_path
+
       assert_response :success
 
       # city_hall は today_inventories がある（フィクスチャで設定済み）
@@ -89,6 +96,7 @@ module Pos
     test "index does not show warning for locations with today inventory" do
       login_as_employee(@employee)
       get pos_locations_path
+
       assert_response :success
 
       # city_hall はフィクスチャで当日在庫が設定されている
@@ -103,6 +111,7 @@ module Pos
       login_as_employee(@employee)
       # city_hall has today inventories from fixtures
       get pos_location_path(@active_location)
+
       assert_redirected_to new_pos_location_sale_path(@active_location)
     end
 
@@ -111,18 +120,21 @@ module Pos
       # Create a new location without inventory
       no_inventory_location = Location.create!(name: "新規販売先", status: :active)
       get pos_location_path(no_inventory_location)
+
       assert_redirected_to new_pos_location_daily_inventory_path(no_inventory_location)
     end
 
     test "show returns 404 for inactive location" do
       login_as_employee(@employee)
       get pos_location_path(@inactive_location)
+
       assert_response :not_found
     end
 
     test "show returns 404 for non-existent location" do
       login_as_employee(@employee)
       get pos_location_path(id: 999999)
+
       assert_response :not_found
     end
   end

--- a/test/controllers/sales_analyses/cross_tables_controller_test.rb
+++ b/test/controllers/sales_analyses/cross_tables_controller_test.rb
@@ -12,12 +12,14 @@ module SalesAnalyses
 
     test "認証済みユーザーが cross_table にアクセスできる" do
       get sales_analyses_cross_table_path(location_id: locations(:city_hall).id, period: 30)
+
       assert_response :success
     end
 
     test "未認証ユーザーはリダイレクトされる" do
       reset!
       get sales_analyses_cross_table_path(location_id: locations(:city_hall).id)
+
       assert_redirected_to "/employee/login"
     end
   end

--- a/test/controllers/sales_analyses/rankings_controller_test.rb
+++ b/test/controllers/sales_analyses/rankings_controller_test.rb
@@ -12,12 +12,14 @@ module SalesAnalyses
 
     test "認証済みユーザーが ranking にアクセスできる" do
       get sales_analyses_ranking_path(location_id: locations(:city_hall).id, period: 30)
+
       assert_response :success
     end
 
     test "未認証ユーザーはリダイレクトされる" do
       reset!
       get sales_analyses_ranking_path(location_id: locations(:city_hall).id)
+
       assert_redirected_to "/employee/login"
     end
   end

--- a/test/controllers/sales_analyses/summaries_controller_test.rb
+++ b/test/controllers/sales_analyses/summaries_controller_test.rb
@@ -12,12 +12,14 @@ module SalesAnalyses
 
     test "認証済みユーザーが summary にアクセスできる" do
       get sales_analyses_summary_path(location_id: locations(:city_hall).id, period: 30)
+
       assert_response :success
     end
 
     test "未認証ユーザーはリダイレクトされる" do
       reset!
       get sales_analyses_summary_path(location_id: locations(:city_hall).id)
+
       assert_redirected_to "/employee/login"
     end
   end

--- a/test/controllers/sales_analyses_controller_test.rb
+++ b/test/controllers/sales_analyses_controller_test.rb
@@ -11,22 +11,26 @@ class SalesAnalysesControllerTest < ActionDispatch::IntegrationTest
 
   test "認証済みユーザーが index にアクセスできる" do
     get sales_analyses_path
+
     assert_response :success
   end
 
   test "period パラメータを受け取る" do
     get sales_analyses_path, params: { period: 7 }
+
     assert_response :success
   end
 
   test "location_id パラメータを受け取る" do
     get sales_analyses_path, params: { location_id: locations(:city_hall).id }
+
     assert_response :success
   end
 
   test "未認証ユーザーはログインページにリダイレクトされる" do
     reset!
     get sales_analyses_path
+
     assert_redirected_to "/employee/login"
   end
 end

--- a/test/controllers/sales_histories/daily_details_controller_test.rb
+++ b/test/controllers/sales_histories/daily_details_controller_test.rb
@@ -15,6 +15,7 @@ module SalesHistories
         location_id: locations(:city_hall).id,
         date: 1.day.ago.to_date.to_s
       )
+
       assert_response :success
     end
 
@@ -24,6 +25,7 @@ module SalesHistories
         location_id: locations(:city_hall).id,
         date: Date.current.to_s
       )
+
       assert_redirected_to "/employee/login"
     end
   end

--- a/test/controllers/sales_histories_controller_test.rb
+++ b/test/controllers/sales_histories_controller_test.rb
@@ -13,16 +13,19 @@ class SalesHistoriesControllerTest < ActionDispatch::IntegrationTest
 
   test "認証済みユーザーが index にアクセスできる" do
     get sales_histories_path
+
     assert_response :success
   end
 
   test "month パラメータで月を指定できる" do
     get sales_histories_path, params: { month: "2026-04" }
+
     assert_response :success
   end
 
   test "不正な month パラメータでも正常に動作する" do
     get sales_histories_path, params: { month: "invalid" }
+
     assert_response :success
   end
 
@@ -30,11 +33,13 @@ class SalesHistoriesControllerTest < ActionDispatch::IntegrationTest
 
   test "認証済みユーザーが日別取引履歴にアクセスできる" do
     get sales_history_path(1.day.ago.to_date.to_s, location_id: locations(:city_hall).id)
+
     assert_response :success
   end
 
   test "不正な日付パラメータではリダイレクトされる" do
     get sales_history_path("invalid-date", location_id: locations(:city_hall).id)
+
     assert_redirected_to sales_histories_path
   end
 
@@ -43,6 +48,7 @@ class SalesHistoriesControllerTest < ActionDispatch::IntegrationTest
   test "未認証ユーザーはログインページにリダイレクトされる" do
     reset!
     get sales_histories_path
+
     assert_redirected_to "/employee/login"
   end
 end

--- a/test/integration/database_configuration_test.rb
+++ b/test/integration/database_configuration_test.rb
@@ -49,7 +49,8 @@ class DatabaseConfigurationTest < ActiveSupport::TestCase
 
     schema_files.each do |db_name, file_path|
       full_path = Rails.root.join(file_path)
-      assert File.exist?(full_path),
+
+      assert_path_exists full_path,
         "Schema file for #{db_name} database should exist at #{file_path}"
     end
   end
@@ -61,6 +62,7 @@ class DatabaseConfigurationTest < ActiveSupport::TestCase
 
     %w[production test].each do |env|
       env_structure = database_structure_for(env)
+
       assert_equal reference_structure, env_structure,
         "Environment '#{env}' database structure should match development environment. " \
         "Inconsistencies: #{structure_diff(reference_structure, env_structure)}"

--- a/test/integration/employee_authentication_test.rb
+++ b/test/integration/employee_authentication_test.rb
@@ -6,6 +6,7 @@ class EmployeeAuthenticationTest < ActionDispatch::IntegrationTest
   test "employee can login successfully" do
     # Navigate to login page
     get "/employee/login"
+
     assert_response :success
 
     # Submit login with valid credentials
@@ -17,11 +18,13 @@ class EmployeeAuthenticationTest < ActionDispatch::IntegrationTest
     # Assert redirect after successful login
     assert_response :redirect
     follow_redirect!
+
     assert_response :success
   end
 
   test "employee cannot login with invalid credentials" do
     get "/employee/login"
+
     assert_response :success
 
     # Submit login with invalid credentials
@@ -40,6 +43,7 @@ class EmployeeAuthenticationTest < ActionDispatch::IntegrationTest
       username: "employee",
       password: "password"
     }
+
     assert_response :redirect
 
     # Logout (Rodauth uses POST for logout, not DELETE)
@@ -51,6 +55,7 @@ class EmployeeAuthenticationTest < ActionDispatch::IntegrationTest
 
     # Following redirect to root will redirect to login since root requires authentication
     follow_redirect!
+
     assert_response :redirect
     assert_redirected_to "/employee/login"
   end
@@ -73,6 +78,7 @@ class EmployeeAuthenticationTest < ActionDispatch::IntegrationTest
 
     # Access close account page
     get "/employee/close-account"
+
     assert_response :success
 
     # Submit close account request with password confirmation
@@ -86,7 +92,8 @@ class EmployeeAuthenticationTest < ActionDispatch::IntegrationTest
     # Verify employee status is now closed
     employee = employees(:verified_employee)
     employee.reload
-    assert employee.closed?, "Employee status should be closed after closing account"
+
+    assert_predicate employee, :closed?, "Employee status should be closed after closing account"
   end
 
   # パスワード変更テスト
@@ -97,6 +104,7 @@ class EmployeeAuthenticationTest < ActionDispatch::IntegrationTest
 
     # Access change password page
     get "/employee/change-password"
+
     assert_response :success
 
     # Submit password change with current and new password
@@ -115,6 +123,7 @@ class EmployeeAuthenticationTest < ActionDispatch::IntegrationTest
       username: employee.username,
       password: "newpassword123"
     }
+
     assert_response :redirect, "Should be able to login with new password"
   end
 
@@ -182,6 +191,7 @@ class EmployeeAuthenticationTest < ActionDispatch::IntegrationTest
 
     # Logout
     post "/employee/logout"
+
     assert_response :redirect
 
     # Try to login again to verify old session is invalid
@@ -190,6 +200,7 @@ class EmployeeAuthenticationTest < ActionDispatch::IntegrationTest
       username: "employee",
       password: "password"
     }
+
     assert_response :redirect, "Should be able to login again after logout"
   end
 
@@ -200,7 +211,8 @@ class EmployeeAuthenticationTest < ActionDispatch::IntegrationTest
       username: "employee",
       password: "password"
     }
-    assert first_device_session.response.redirect?, "First device should login successfully"
+
+    assert_predicate first_device_session.response, :redirect?, "First device should login successfully"
 
     # Simulate second device login (using a different session)
     second_device_session = open_session
@@ -208,12 +220,14 @@ class EmployeeAuthenticationTest < ActionDispatch::IntegrationTest
       username: "employee",
       password: "password"
     }
-    assert second_device_session.response.redirect?, "Second device should login successfully"
+
+    assert_predicate second_device_session.response, :redirect?, "Second device should login successfully"
 
     # Both sessions should be valid (concurrent login allowed)
     # Verify first session is still valid by accessing a protected page
     first_device_session.get root_path
-    assert first_device_session.response.successful?, "First device session should remain valid"
+
+    assert_predicate first_device_session.response, :successful?, "First device session should remain valid"
   end
 
   # 業務機能アクセステスト（Requirement 9.7）
@@ -223,6 +237,7 @@ class EmployeeAuthenticationTest < ActionDispatch::IntegrationTest
 
     # Employee should be able to access root path (業務機能)
     get root_path
+
     assert_response :success, "Employee should be able to access business functions"
   end
 

--- a/test/models/additional_order_test.rb
+++ b/test/models/additional_order_test.rb
@@ -36,6 +36,7 @@ class AdditionalOrderTest < ActiveSupport::TestCase
     )
 
     inventory.reload
+
     assert_equal initial_stock + 5, inventory.stock
 
     future_date = Date.current + 365
@@ -54,6 +55,7 @@ class AdditionalOrderTest < ActiveSupport::TestCase
       catalog: catalogs(:daily_bento_a),
       inventory_date: future_date
     )
+
     assert_equal 10, new_inventory.stock
   end
 

--- a/test/models/additional_orders/order_form_test.rb
+++ b/test/models/additional_orders/order_form_test.rb
@@ -19,10 +19,10 @@ module AdditionalOrders
     test "全弁当カタログからフォーム項目を構築し入力数量で絞り込める" do
       form = OrderForm.new(location: @location, catalogs: @catalogs, stock_map: @stock_map)
 
-      assert form.items.any?
+      assert_predicate form.items, :any?
       form.items.each do |item|
         assert_kind_of AdditionalOrders::OrderItem, item
-        assert item.catalog_name.present?
+        assert_predicate item.catalog_name, :present?
         assert_equal 0, item.quantity
       end
       assert_equal @stock_map.values.sum, form.total_available_stock
@@ -58,8 +58,9 @@ module AdditionalOrders
 
     test "発注数が未入力の場合や登録エラー時は保存されない" do
       form = OrderForm.new(location: @location, catalogs: @catalogs, stock_map: @stock_map)
+
       assert_not form.save(employee: @employee)
-      assert form.errors[:base].any?
+      assert_predicate form.errors[:base], :any?
 
       bento_a = catalogs(:daily_bento_a)
       form_with_input = OrderForm.new(
@@ -83,7 +84,7 @@ module AdditionalOrders
       form = OrderForm.new(location: @location, catalogs: @catalogs, stock_map: @stock_map)
 
       form.inventory_items.each do |item|
-        assert item.in_inventory?, "#{item.catalog_name} は在庫登録済みであるべき"
+        assert_predicate item, :in_inventory?, "#{item.catalog_name} は在庫登録済みであるべき"
       end
 
       form.non_inventory_items.each do |item|
@@ -95,6 +96,7 @@ module AdditionalOrders
 
     test "検索クエリで商品の表示・非表示を判定できる" do
       form_without_query = OrderForm.new(location: @location, catalogs: @catalogs, stock_map: @stock_map)
+
       form_without_query.items.each do |item|
         assert form_without_query.visible?(item), "検索クエリなしでは全商品が表示される"
       end
@@ -127,6 +129,7 @@ module AdditionalOrders
       end
 
       created_inventory = @location.today_inventories.find_by!(catalog_id: unlisted.id)
+
       assert_equal 3, created_inventory.stock
     end
 

--- a/test/models/catalog_price_test.rb
+++ b/test/models/catalog_price_test.rb
@@ -30,17 +30,21 @@ class CatalogPriceTest < ActiveSupport::TestCase
     now = Time.current
 
     before_start = CatalogPrice.new(catalog: catalog, kind: :regular, price: 500, effective_from: now, effective_until: 1.day.ago)
+
     assert_not before_start.valid?
     assert_includes before_start.errors[:effective_until], "は適用開始日時より後の日時を指定してください"
 
     same_time = CatalogPrice.new(catalog: catalog, kind: :regular, price: 500, effective_from: now, effective_until: now)
+
     assert_not same_time.valid?
 
     after_start = CatalogPrice.new(catalog: catalog, kind: :regular, price: 500, effective_from: now, effective_until: 1.day.from_now)
-    assert after_start.valid?
+
+    assert_predicate after_start, :valid?
 
     no_end = CatalogPrice.new(catalog: catalog, kind: :regular, price: 500, effective_from: now, effective_until: nil)
-    assert no_end.valid?
+
+    assert_predicate no_end, :valid?
   end
 
   test "有効期間内の価格のみが取得される" do
@@ -69,21 +73,24 @@ class CatalogPriceTest < ActiveSupport::TestCase
     assert_equal past_price, catalog.prices.price_by_kind(kind: :regular, at: 3.days.ago)
 
     empty_catalog = catalogs(:discontinued_bento)
+
     assert_nil empty_catalog.prices.price_by_kind(kind: :regular)
   end
 
   test "新しい価格を設定すると既存の価格が終了する" do
     catalog = catalogs(:daily_bento_a)
     old_price = catalog_prices(:daily_bento_a_regular)
+
     assert_nil old_price.effective_until
 
     new_price = CatalogPrice.create_with_history!(catalog: catalog, kind: :regular, price: 600)
 
-    assert new_price.persisted?
+    assert_predicate new_price, :persisted?
     assert_equal 600, new_price.price
     assert_nil new_price.effective_until
 
     old_price.reload
+
     assert_not_nil old_price.effective_until
   end
 
@@ -96,6 +103,7 @@ class CatalogPriceTest < ActiveSupport::TestCase
     end
 
     old_price.reload
+
     assert_nil old_price.effective_until
   end
 end

--- a/test/models/catalog_pricing_rule_test.rb
+++ b/test/models/catalog_pricing_rule_test.rb
@@ -32,17 +32,21 @@ class CatalogPricingRuleTest < ActiveSupport::TestCase
     today = Date.current
 
     before_start = CatalogPricingRule.new(target_catalog: catalog, price_kind: :bundle, trigger_category: :bento, max_per_trigger: 1, valid_from: today, valid_until: 1.day.ago.to_date)
+
     assert_not before_start.valid?
     assert_includes before_start.errors[:valid_until], "は有効開始日より後の日付を指定してください"
 
     same_day = CatalogPricingRule.new(target_catalog: catalog, price_kind: :bundle, trigger_category: :bento, max_per_trigger: 1, valid_from: today, valid_until: today)
+
     assert_not same_day.valid?
 
     after_start = CatalogPricingRule.new(target_catalog: catalog, price_kind: :bundle, trigger_category: :bento, max_per_trigger: 1, valid_from: today, valid_until: 1.day.from_now.to_date)
-    assert after_start.valid?
+
+    assert_predicate after_start, :valid?
 
     no_end = CatalogPricingRule.new(target_catalog: catalog, price_kind: :bundle, trigger_category: :bento, max_per_trigger: 1, valid_from: today, valid_until: nil)
-    assert no_end.valid?
+
+    assert_predicate no_end, :valid?
   end
 
   test "有効期間内のルールのみが取得される" do

--- a/test/models/catalog_test.rb
+++ b/test/models/catalog_test.rb
@@ -30,6 +30,7 @@ class CatalogTest < ActiveSupport::TestCase
 
   test "新規作成時のデフォルトカテゴリは未設定である" do
     catalog = Catalog.new(name: "デフォルトテスト")
+
     assert_nil catalog.category
   end
 
@@ -93,6 +94,7 @@ class CatalogTest < ActiveSupport::TestCase
     assert_equal bundle_price, catalog.price_by_kind(:bundle)
 
     catalog_without_prices = Catalog.create!(name: "価格なしテスト", kana: "カカクナシテスト", category: :bento)
+
     assert_nil catalog_without_prices.price_by_kind(:regular)
   end
 
@@ -106,7 +108,7 @@ class CatalogTest < ActiveSupport::TestCase
       reason: "販売終了"
     )
 
-    assert discontinued_catalog.discontinued?
+    assert_predicate discontinued_catalog, :discontinued?
     assert_not available_catalog.discontinued?
 
     assert_includes Catalog.available, available_catalog
@@ -146,6 +148,6 @@ class CatalogTest < ActiveSupport::TestCase
 
     assert_not result, "destroy は false を返すべき"
     assert_equal initial_count, Catalog.count, "レコード数は変わらないべき"
-    assert catalog.persisted?, "レコードは削除されていないべき"
+    assert_predicate catalog, :persisted?, "レコードは削除されていないべき"
   end
 end

--- a/test/models/catalogs/bento_creator_test.rb
+++ b/test/models/catalogs/bento_creator_test.rb
@@ -11,16 +11,16 @@ class Catalogs::BentoCreatorTest < ActiveSupport::TestCase
       description: "海苔と鮭フレークをのせた弁当"
     )
 
-    assert creator.valid?
+    assert_predicate creator, :valid?
 
     assert_difference [ "Catalog.count", "CatalogPrice.count" ], 1 do
       assert_no_difference "CatalogPricingRule.count" do
         catalog = creator.create!
 
         assert_equal "のり弁当", catalog.name
-        assert catalog.bento?
+        assert_predicate catalog, :bento?
         assert_equal 450, catalog.prices.first.price
-        assert catalog.prices.first.regular?
+        assert_predicate catalog.prices.first, :regular?
         assert_equal "海苔と鮭フレークをのせた弁当", catalog.description
       end
     end
@@ -34,6 +34,7 @@ class Catalogs::BentoCreatorTest < ActiveSupport::TestCase
     )
 
     catalog = creator.create!
+
     assert_equal "", catalog.description
   end
 
@@ -41,8 +42,8 @@ class Catalogs::BentoCreatorTest < ActiveSupport::TestCase
     creator = Catalogs::BentoCreator.new(name: "", regular_price: 0)
 
     assert_not creator.valid?
-    assert creator.errors[:name].any?
-    assert creator.errors[:regular_price].any?
+    assert_predicate creator.errors[:name], :any?
+    assert_predicate creator.errors[:regular_price], :any?
 
     assert_no_difference [ "Catalog.count", "CatalogPrice.count" ] do
       assert_raises(ActiveRecord::RecordInvalid) { creator.create! }

--- a/test/models/catalogs/creator_factory_test.rb
+++ b/test/models/catalogs/creator_factory_test.rb
@@ -5,10 +5,12 @@ require "test_helper"
 class Catalogs::CreatorFactoryTest < ActiveSupport::TestCase
   test "カテゴリに応じた作成クラスを生成し不明なカテゴリではエラーになる" do
     bento_creator = Catalogs::CreatorFactory.build("bento", name: "のり弁当", regular_price: 450)
+
     assert_kind_of Catalogs::BentoCreator, bento_creator
     assert_equal "のり弁当", bento_creator.name
 
     side_menu_creator = Catalogs::CreatorFactory.build("side_menu", name: "唐揚げ", regular_price: 150, bundle_price: 100)
+
     assert_kind_of Catalogs::SideMenuCreator, side_menu_creator
     assert_equal "唐揚げ", side_menu_creator.name
 

--- a/test/models/catalogs/price_validator_test.rb
+++ b/test/models/catalogs/price_validator_test.rb
@@ -14,12 +14,14 @@ class Catalogs::PriceValidatorTest < ActiveSupport::TestCase
     assert_not validator.price_exists?(catalogs(:daily_bento_a), :bundle)
 
     price = validator.find_price(catalogs(:daily_bento_a), :regular)
+
     assert_kind_of CatalogPrice, price
     assert_equal 550, price.price
 
     assert_nil validator.find_price(catalogs(:miso_soup), :regular)
 
     found = validator.find_price!(catalogs(:daily_bento_a), :regular)
+
     assert_equal 550, found.price
   end
 
@@ -48,6 +50,7 @@ class Catalogs::PriceValidatorTest < ActiveSupport::TestCase
 
     miso_soup = catalogs(:miso_soup)
     missing_miso_soup = result.find { |r| r[:catalog].id == miso_soup.id }
+
     assert_not_nil missing_miso_soup
     assert_includes missing_miso_soup[:missing_kinds], "regular"
 
@@ -77,6 +80,7 @@ class Catalogs::PriceValidatorTest < ActiveSupport::TestCase
     result = Catalogs::PriceValidator.new.catalogs_with_missing_prices
 
     missing = result.find { |r| r[:catalog].id == miso_soup.id }
+
     assert_not_nil missing
     assert_includes missing[:missing_kinds], "bundle"
   end

--- a/test/models/catalogs/pricing_rule_creator_test.rb
+++ b/test/models/catalogs/pricing_rule_creator_test.rb
@@ -48,9 +48,11 @@ class Catalogs::PricingRuleCreatorTest < ActiveSupport::TestCase
 
     assert_difference "CatalogPricingRule.count", 2 do
       rule = creator.create(price_kind: :regular, trigger_category: :bento, max_per_trigger: 1, valid_from: 1.month.from_now.to_date)
+
       assert_kind_of CatalogPricingRule, rule
 
       rule2 = creator.create(price_kind: :regular, trigger_category: :bento, max_per_trigger: 1, valid_from: 1.month.ago.to_date, valid_until: 1.week.ago.to_date)
+
       assert_kind_of CatalogPricingRule, rule2
     end
 
@@ -64,6 +66,7 @@ class Catalogs::PricingRuleCreatorTest < ActiveSupport::TestCase
     creator = Catalogs::PricingRuleCreator.new(target_catalog: rule.target_catalog)
 
     updated = creator.update(rule, max_per_trigger: 3)
+
     assert_equal 3, updated.max_per_trigger
 
     assert_raises(ActiveRecord::RecordInvalid) do
@@ -80,6 +83,7 @@ class Catalogs::PricingRuleCreatorTest < ActiveSupport::TestCase
     creator = Catalogs::PricingRuleCreator.new(target_catalog: catalog)
 
     updated = creator.update(rule, max_per_trigger: 2)
+
     assert_equal 2, updated.max_per_trigger
 
     error = assert_raises(Errors::MissingPriceError) do

--- a/test/models/catalogs/side_menu_creator_test.rb
+++ b/test/models/catalogs/side_menu_creator_test.rb
@@ -11,15 +11,15 @@ class Catalogs::SideMenuCreatorTest < ActiveSupport::TestCase
       description: "ジューシーな鶏の唐揚げ"
     )
 
-    assert creator.valid?
+    assert_predicate creator, :valid?
 
     assert_difference [ "Catalog.count", "CatalogPrice.count" ], 1 do
       assert_no_difference "CatalogPricingRule.count" do
         catalog = creator.create!
 
         assert_equal "唐揚げ", catalog.name
-        assert catalog.side_menu?
-        assert catalog.prices.first.regular?
+        assert_predicate catalog, :side_menu?
+        assert_predicate catalog.prices.first, :regular?
         assert_equal "ジューシーな鶏の唐揚げ", catalog.description
       end
     end
@@ -33,7 +33,7 @@ class Catalogs::SideMenuCreatorTest < ActiveSupport::TestCase
       bundle_price: 100
     )
 
-    assert creator.valid?
+    assert_predicate creator, :valid?
 
     assert_difference "Catalog.count", 1 do
       assert_difference "CatalogPrice.count", 2 do
@@ -44,8 +44,9 @@ class Catalogs::SideMenuCreatorTest < ActiveSupport::TestCase
           assert_equal 100, catalog.prices.find_by(kind: :bundle).price
 
           rule = CatalogPricingRule.find_by(target_catalog: catalog)
-          assert rule.bundle?
-          assert rule.triggered_by_bento?
+
+          assert_predicate rule, :bundle?
+          assert_predicate rule, :triggered_by_bento?
           assert_equal 1, rule.max_per_trigger
         end
       end
@@ -56,8 +57,8 @@ class Catalogs::SideMenuCreatorTest < ActiveSupport::TestCase
     creator = Catalogs::SideMenuCreator.new(name: "", regular_price: 0)
 
     assert_not creator.valid?
-    assert creator.errors[:name].any?
-    assert creator.errors[:regular_price].any?
+    assert_predicate creator.errors[:name], :any?
+    assert_predicate creator.errors[:regular_price], :any?
 
     assert_no_difference [ "Catalog.count", "CatalogPrice.count", "CatalogPricingRule.count" ] do
       assert_raises(ActiveRecord::RecordInvalid) { creator.create! }
@@ -68,8 +69,9 @@ class Catalogs::SideMenuCreatorTest < ActiveSupport::TestCase
     creator_with_bad_bundle = Catalogs::SideMenuCreator.new(
       name: "テスト", kana: "テスト", regular_price: 150, bundle_price: 0
     )
+
     assert_not creator_with_bad_bundle.valid?
-    assert creator_with_bad_bundle.errors[:bundle_price].any?
+    assert_predicate creator_with_bad_bundle.errors[:bundle_price], :any?
   end
 
   test "商品名が重複している場合は作成できない" do

--- a/test/models/daily_inventories/inventory_form_test.rb
+++ b/test/models/daily_inventories/inventory_form_test.rb
@@ -32,7 +32,7 @@ module DailyInventories
       items_with_input = ItemBuilder.from_params(@catalogs, submitted)
       form_with_input = InventoryForm.new(location: @location, items: items_with_input)
 
-      assert form_with_input.valid?
+      assert_predicate form_with_input, :valid?
       assert_equal 2, form_with_input.selected_count
       assert_equal 15, form_with_input.selected_items.find { |i| i.catalog_id == @bento_a.id }.stock
     end
@@ -41,10 +41,10 @@ module DailyInventories
       items = ItemBuilder.from_params(@catalogs, {})
       form = InventoryForm.new(location: @location, items: items)
 
-      assert form.bento_items.any?
+      assert_predicate form.bento_items, :any?
       form.bento_items.each { |item| assert_equal "bento", item.category }
 
-      assert form.side_menu_items.any?
+      assert_predicate form.side_menu_items, :any?
       form.side_menu_items.each { |item| assert_equal "side_menu", item.category }
     end
 
@@ -53,15 +53,19 @@ module DailyInventories
 
       form = InventoryForm.new(location: @location, items: items, search_query: @bento_a.name[0..2])
       matching_item = form.items.find { |i| i.catalog_id == @bento_a.id }
+
       assert form.visible?(matching_item)
 
       form_no_match = InventoryForm.new(location: @location, items: items, search_query: "存在しない商品名")
+
       assert_not form_no_match.visible?(form_no_match.items.first)
 
       form_blank = InventoryForm.new(location: @location, items: items, search_query: "  弁当  ")
+
       assert_equal "弁当", form_blank.search_query
 
       form_empty = InventoryForm.new(location: @location, items: items, search_query: "   ")
+
       assert_nil form_empty.search_query
     end
 
@@ -81,6 +85,7 @@ module DailyInventories
 
       empty_items = ItemBuilder.from_params(@catalogs, {})
       empty_form = InventoryForm.new(location: location, items: empty_items)
+
       assert_not empty_form.save
       assert_equal 0, empty_form.created_count
 

--- a/test/models/daily_inventories/inventory_item_test.rb
+++ b/test/models/daily_inventories/inventory_item_test.rb
@@ -15,7 +15,7 @@ module DailyInventories
 
       custom = InventoryItem.new(catalog_id: 2, catalog_name: "特製弁当", category: "bento", selected: true, stock: 20)
 
-      assert custom.selected?
+      assert_predicate custom, :selected?
       assert_equal 20, custom.stock
       assert_equal "bento", custom.category
     end

--- a/test/models/daily_inventories/item_builder_test.rb
+++ b/test/models/daily_inventories/item_builder_test.rb
@@ -22,7 +22,8 @@ module DailyInventories
 
       assert_equal 2, items.size
       item_a = items.find { |i| i.catalog_id == @bento_a.id }
-      assert item_a.selected?
+
+      assert_predicate item_a, :selected?
       assert_equal 15, item_a.stock
       assert_equal @bento_a.name, item_a.catalog_name
       assert_equal @bento_a.category, item_a.category
@@ -45,7 +46,7 @@ module DailyInventories
       items = ItemBuilder.from_params(@catalogs, submitted)
       item_a = items.find { |i| i.catalog_id == @bento_a.id }
 
-      assert item_a.selected?
+      assert_predicate item_a, :selected?
       assert_equal 10, item_a.stock
     end
 
@@ -60,10 +61,12 @@ module DailyInventories
       items = ItemBuilder.from_inventories(@catalogs, inventories_by_catalog_id)
 
       item_a = items.find { |i| i.catalog_id == @bento_a.id }
-      assert item_a.selected?
+
+      assert_predicate item_a, :selected?
       assert_equal 20, item_a.stock
 
       item_b = items.find { |i| i.catalog_id == @bento_b.id }
+
       assert_not item_b.selected?
       assert_equal InventoryItem::DEFAULT_STOCK, item_b.stock
     end

--- a/test/models/daily_inventory_test.rb
+++ b/test/models/daily_inventory_test.rb
@@ -30,12 +30,14 @@ class DailyInventoryTest < ActiveSupport::TestCase
 
   test "利用可能在庫数は総在庫から予約在庫を引いた値であり負数は許可されない" do
     inventory = daily_inventories(:city_hall_bento_b_today)
+
     assert_equal 3, inventory.available_stock  # stock: 5, reserved_stock: 2
 
     over_reserved = DailyInventory.new(
       location: locations(:city_hall), catalog: catalogs(:daily_bento_a),
       inventory_date: Date.current + 1.day, stock: 5, reserved_stock: 10
     )
+
     assert_not over_reserved.valid?
     assert_includes over_reserved.errors[:base], "利用可能在庫数（stock - reserved_stock）は0以上である必要があります"
 
@@ -43,7 +45,8 @@ class DailyInventoryTest < ActiveSupport::TestCase
       location: locations(:city_hall), catalog: catalogs(:daily_bento_a),
       inventory_date: Date.current + 2.days, stock: 5, reserved_stock: 5
     )
-    assert exactly_zero.valid?
+
+    assert_predicate exactly_zero, :valid?
   end
 
   test "在庫から販売数を減算できる" do
@@ -59,6 +62,7 @@ class DailyInventoryTest < ActiveSupport::TestCase
 
     inventory.decrement_stock!(inventory.stock)
     inventory.reload
+
     assert_equal 0, inventory.stock
 
     assert_raises(DailyInventory::InsufficientStockError) { inventory.decrement_stock!(1) }
@@ -90,6 +94,7 @@ class DailyInventoryTest < ActiveSupport::TestCase
 
     assert_difference "DailyInventory.count", 2 do
       result = DailyInventory.bulk_create(location: location, items: items)
+
       assert_equal 2, result
     end
 
@@ -135,10 +140,12 @@ class DailyInventoryTest < ActiveSupport::TestCase
 
     assert_difference "DailyInventory.count", 1 do
       result = DailyInventory.bulk_recreate(location: location, items: items)
+
       assert_equal 2, result
     end
 
     recreated = DailyInventory.where(location: location, inventory_date: Date.current)
+
     assert_equal 2, recreated.count
     assert_equal 20, recreated.find_by(catalog: catalogs(:daily_bento_a)).stock
   end
@@ -157,6 +164,7 @@ class DailyInventoryTest < ActiveSupport::TestCase
 
     assert_no_difference "DailyInventory.count" do
       result = DailyInventory.bulk_recreate(location: location, items: items)
+
       assert_equal :sales_already_started, result
     end
   end
@@ -178,9 +186,11 @@ class DailyInventoryTest < ActiveSupport::TestCase
     ]
 
     result = DailyInventory.bulk_recreate(location: location, items: items)
+
     assert_equal 2, result
 
     remaining = DailyInventory.where(location: location, inventory_date: Date.current)
+
     assert_equal 2, remaining.count
     assert_nil remaining.find_by(catalog: catalogs(:daily_bento_a))
     assert_equal 8, remaining.find_by(catalog: catalogs(:daily_bento_b)).stock
@@ -201,6 +211,7 @@ class DailyInventoryTest < ActiveSupport::TestCase
     DailyInventory.bulk_recreate(location: location, items: items)
 
     recreated = DailyInventory.find_by(location: location, catalog: catalogs(:daily_bento_a), inventory_date: Date.current)
+
     assert_equal 0, recreated.lock_version
     assert_not DailyInventory.sales_started?(location: location)
   end
@@ -222,6 +233,7 @@ class DailyInventoryTest < ActiveSupport::TestCase
 
     assert_no_difference "DailyInventory.count" do
       result = DailyInventory.bulk_create(location: location, items: items)
+
       assert_equal 0, result
     end
   end

--- a/test/models/discount_test.rb
+++ b/test/models/discount_test.rb
@@ -27,17 +27,21 @@ class DiscountTest < ActiveSupport::TestCase
     today = Date.current
 
     before_start = Discount.new(discountable: coupon, name: "テスト", valid_from: today, valid_until: 1.day.ago.to_date)
+
     assert_not before_start.valid?
     assert_includes before_start.errors[:valid_until], "は有効開始日より後の日付を指定してください"
 
     same_day = Discount.new(discountable: coupon, name: "テスト", valid_from: today, valid_until: today)
+
     assert_not same_day.valid?
 
     after_start = Discount.new(discountable: coupon, name: "テスト", valid_from: today, valid_until: 1.day.from_now.to_date)
-    assert after_start.valid?
+
+    assert_predicate after_start, :valid?
 
     no_end = Discount.new(discountable: coupon, name: "テスト", valid_from: today, valid_until: nil)
-    assert no_end.valid?
+
+    assert_predicate no_end, :valid?
   end
 
   test "有効な割引のみが取得される" do

--- a/test/models/employee_test.rb
+++ b/test/models/employee_test.rb
@@ -24,17 +24,21 @@ class EmployeeTest < ActiveSupport::TestCase
 
   test "ユーザー名は有効なアカウント間で一意であり閉鎖アカウントは再利用できる" do
     duplicate = Employee.new(username: "employee", password: "password", status: :verified)
+
     assert_not duplicate.valid?
     assert_includes duplicate.errors[:username], "はすでに存在します"
 
     case_variant = Employee.new(username: "EMPLOYEE", password: "password", status: :verified)
+
     assert_not case_variant.valid?
 
     reused = Employee.new(username: "closed_employee", password: "password", status: :verified)
-    assert reused.valid?
+
+    assert_predicate reused, :valid?
 
     Employee.create!(username: "duplicate_closed", password: "password", status: :closed)
     second_closed = Employee.new(username: "duplicate_closed", password: "password", status: :closed)
-    assert second_closed.valid?
+
+    assert_predicate second_closed, :valid?
   end
 end

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -51,7 +51,7 @@ class LocationTest < ActiveSupport::TestCase
   test "当日の在庫がある販売先は在庫ありと判定される" do
     city_hall = locations(:city_hall)
 
-    assert city_hall.has_today_inventory?
+    assert_predicate city_hall, :has_today_inventory?
   end
 
   test "当日の在庫がない販売先は在庫なしと判定される" do

--- a/test/models/refunds/refund_form_test.rb
+++ b/test/models/refunds/refund_form_test.rb
@@ -96,14 +96,17 @@ module Refunds
 
       # 弁当A: 修正後1個
       bento_a_item = corrected.find { |item| item[:catalog].id == @catalog_bento_a.id }
+
       assert_equal 1, bento_a_item[:quantity]
 
       # サラダ: 0個（含まれない）
       salad_item = corrected.find { |item| item[:catalog].id == @catalog_salad.id }
+
       assert_nil salad_item
 
       # 弁当B: 新規追加1個
       bento_b_item = corrected.find { |item| item[:catalog].id == @catalog_bento_b.id }
+
       assert_equal 1, bento_b_item[:quantity]
     end
 
@@ -124,7 +127,7 @@ module Refunds
         }
       )
 
-      assert form.has_any_changes?
+      assert_predicate form, :has_any_changes?
     end
 
     test "商品数量を減らすとhas_any_changes?がtrueになる" do
@@ -141,7 +144,7 @@ module Refunds
         }
       )
 
-      assert form.has_any_changes?
+      assert_predicate form, :has_any_changes?
     end
 
     test "全商品を0にするとhas_any_changes?がtrueになる" do
@@ -158,8 +161,8 @@ module Refunds
         }
       )
 
-      assert form.has_any_changes?
-      assert form.all_items_zero?
+      assert_predicate form, :has_any_changes?
+      assert_predicate form, :all_items_zero?
     end
 
     # === バリデーションテスト ===
@@ -192,7 +195,7 @@ module Refunds
         }
       )
 
-      assert form.valid?
+      assert_predicate form, :valid?
     end
 
     # === preview_adjustment_amount テスト ===
@@ -257,7 +260,7 @@ module Refunds
         }
       )
 
-      assert form.has_any_changes?
+      assert_predicate form, :has_any_changes?
     end
 
     test "discount_quantities_for_refunderがクーポン数量を正しく返す" do
@@ -282,6 +285,7 @@ module Refunds
       )
 
       result = form.discount_quantities_for_refunder
+
       assert_equal 1, result[discount.id]
     end
 
@@ -298,7 +302,8 @@ module Refunds
       )
 
       items = form.corrected_items
-      assert items.any?
+
+      assert_predicate items, :any?
       items.each do |item|
         assert_respond_to item, :catalog_name
         assert_respond_to item, :quantity
@@ -330,11 +335,13 @@ module Refunds
       )
 
       result = form.preview_price_result
+
       assert_equal 0, result[:final_total]
       assert_empty result[:items_with_prices]
 
       details = result[:discount_details]
       coupon_detail = details.find { |d| d[:discount_id] == discount.id }
+
       assert_equal 0, coupon_detail[:quantity]
       assert_equal 1, coupon_detail[:requested_quantity]
     end
@@ -352,6 +359,7 @@ module Refunds
       )
 
       tab_keys = form.tab_items.map { |t| t[:key] }
+
       assert_includes tab_keys, :bento
     end
   end

--- a/test/models/sale_discount_test.rb
+++ b/test/models/sale_discount_test.rb
@@ -29,10 +29,12 @@ class SaleDiscountTest < ActiveSupport::TestCase
     existing = sale_discounts(:completed_sale_fifty_yen)
 
     duplicate = SaleDiscount.new(sale: existing.sale, discount: existing.discount, discount_amount: 50, quantity: 1)
+
     assert_not duplicate.valid?
     assert_includes duplicate.errors[:discount_id], "同じ割引を複数回適用できません"
 
     different_sale = SaleDiscount.new(sale: sales(:prefectural_office_sale), discount: existing.discount, discount_amount: 50, quantity: 1)
-    assert different_sale.valid?
+
+    assert_predicate different_sale, :valid?
   end
 end

--- a/test/models/sale_item_test.rb
+++ b/test/models/sale_item_test.rb
@@ -39,11 +39,13 @@ class SaleItemTest < ActiveSupport::TestCase
     )
 
     sale_item.valid?
+
     assert_equal 1650, sale_item.line_total
 
     sale_item.unit_price = nil
     sale_item.line_total = 100
     sale_item.valid?
+
     assert_equal 100, sale_item.line_total, "単価が未入力の場合は小計を上書きしない"
   end
 end

--- a/test/models/sale_test.rb
+++ b/test/models/sale_test.rb
@@ -48,6 +48,7 @@ class SaleTest < ActiveSupport::TestCase
       voided_at: nil,
       voided_by_employee: nil
     )
+
     assert_not voided_sale.valid?
     assert_includes voided_sale.errors[:voided_at], "を入力してください"
     assert_includes voided_sale.errors[:voided_by_employee], "を入力してください"
@@ -62,7 +63,8 @@ class SaleTest < ActiveSupport::TestCase
       voided_at: nil,
       voided_by_employee: nil
     )
-    assert completed_sale.valid?
+
+    assert_predicate completed_sale, :valid?
   end
 
   # --- スコープテスト ---
@@ -100,7 +102,7 @@ class SaleTest < ActiveSupport::TestCase
       sale.void!(voided_by: employees(:verified_employee))
       sale.reload
 
-      assert sale.voided?
+      assert_predicate sale, :voided?
       assert_equal Time.current, sale.voided_at
       assert_equal employees(:verified_employee), sale.voided_by_employee
     end

--- a/test/models/sales/analysis_summary_test.rb
+++ b/test/models/sales/analysis_summary_test.rb
@@ -20,10 +20,10 @@ module Sales
 
       assert result.key?(:staff)
       assert result.key?(:citizen)
-      assert result[:staff][:quantity] > 0
-      assert result[:citizen][:quantity] > 0
-      assert result[:staff][:amount] > 0
-      assert result[:citizen][:amount] > 0
+      assert_operator result[:staff][:quantity], :>, 0
+      assert_operator result[:citizen][:quantity], :>, 0
+      assert_operator result[:staff][:amount], :>, 0
+      assert_operator result[:citizen][:amount], :>, 0
     end
 
     test "顧客タイプ別サマリーは取消済みの販売を含まない" do
@@ -60,11 +60,12 @@ module Sales
 
       assert result.key?(:staff)
       assert result.key?(:citizen)
-      assert result[:staff].length <= 5
-      assert result[:citizen].length <= 5
+      assert_operator result[:staff].length, :<=, 5
+      assert_operator result[:citizen].length, :<=, 5
 
       # 職員: 弁当A が最も多い（staff_1, staff_3, staff_4 + completed_sale = 4個）
       top_staff = result[:staff].first
+
       assert_equal catalogs(:daily_bento_a).name, top_staff[:catalog_name]
     end
 
@@ -72,6 +73,7 @@ module Sales
       result = @summary.ranking(limit: 10)
 
       all_names = result[:staff].map { |e| e[:catalog_name] } + result[:citizen].map { |e| e[:catalog_name] }
+
       assert_not_includes all_names, catalogs(:salad).name
     end
 
@@ -89,12 +91,13 @@ module Sales
     test "クロス集計は商品ごとに職員と一般の販売数量を並べる" do
       result = @summary.cross_table
 
-      assert result.is_a?(Array)
+      assert_kind_of Array, result
 
       bento_a = result.find { |r| r[:catalog_name] == catalogs(:daily_bento_a).name }
+
       assert_not_nil bento_a
-      assert bento_a[:staff_quantity] > 0
-      assert bento_a[:citizen_quantity] > 0
+      assert_operator bento_a[:staff_quantity], :>, 0
+      assert_operator bento_a[:citizen_quantity], :>, 0
       assert_equal bento_a[:staff_quantity] + bento_a[:citizen_quantity], bento_a[:total_quantity]
     end
 
@@ -102,6 +105,7 @@ module Sales
       result = @summary.cross_table
 
       all_names = result.map { |r| r[:catalog_name] }
+
       assert_not_includes all_names, catalogs(:salad).name
     end
 
@@ -109,6 +113,7 @@ module Sales
       result = @summary.cross_table
 
       totals = result.map { |r| r[:total_quantity] }
+
       assert_equal totals.sort.reverse, totals
     end
   end

--- a/test/models/sales/cart_form_test.rb
+++ b/test/models/sales/cart_form_test.rb
@@ -16,6 +16,7 @@ module Sales
 
     test "カートを構築し商品の数量・顧客種別・クーポンを入力できる" do
       form = CartForm.new(location: @location, inventories: @inventories, discounts: @discounts)
+
       assert_equal @inventories.count, form.items.count
       form.items.each do |item|
         assert_equal 0, item.quantity
@@ -29,25 +30,27 @@ module Sales
       }
       form_with_input = CartForm.new(location: @location, inventories: @inventories, discounts: @discounts, submitted: submitted)
       bento_item = form_with_input.items.find { |i| i.catalog_id == @bento_a.id }
+
       assert_equal 3, bento_item.quantity
-      assert bento_item.in_cart?
-      assert form_with_input.has_items_in_cart?
+      assert_predicate bento_item, :in_cart?
+      assert_predicate form_with_input, :has_items_in_cart?
       assert_equal "staff", form_with_input.customer_type
 
       discount = discounts(:fifty_yen_discount)
       coupon_submitted = { "coupon" => { discount.id.to_s => { "quantity" => "1" } } }
       form_with_coupon = CartForm.new(location: @location, inventories: @inventories, discounts: @discounts, submitted: coupon_submitted)
+
       assert_equal 1, form_with_coupon.coupon_quantity(discount)
     end
 
     test "商品をカテゴリごとに分類できる" do
       form = CartForm.new(location: @location, inventories: @inventories, discounts: @discounts)
 
-      assert form.bento_items.any?
-      form.bento_items.each { |item| assert item.bento? }
+      assert_predicate form.bento_items, :any?
+      form.bento_items.each { |item| assert_predicate item, :bento? }
 
-      assert form.side_menu_items.any?
-      form.side_menu_items.each { |item| assert item.side_menu? }
+      assert_predicate form.side_menu_items, :any?
+      form.side_menu_items.each { |item| assert_predicate item, :side_menu? }
     end
 
     test "カート内の商品を絞り込み弁当の合計数量を計算できる" do
@@ -67,6 +70,7 @@ module Sales
     test "カートの合計金額を計算しセット割引が適用される" do
       form_empty = CartForm.new(location: @location, inventories: @inventories, discounts: @discounts)
       empty_result = form_empty.price_result
+
       assert_equal 0, empty_result[:subtotal]
       assert_equal 0, empty_result[:final_total]
       assert_empty empty_result[:items_with_prices]
@@ -74,6 +78,7 @@ module Sales
       submitted_single = { @bento_a.id.to_s => { "quantity" => "1" } }
       form_single = CartForm.new(location: @location, inventories: @inventories, discounts: @discounts, submitted: submitted_single)
       single_result = form_single.price_result
+
       assert_equal 550, single_result[:subtotal]
       assert_equal 550, single_result[:final_total]
 
@@ -83,6 +88,7 @@ module Sales
       }
       form_bundle = CartForm.new(location: @location, inventories: @inventories, discounts: @discounts, submitted: submitted_bundle)
       bundle_result = form_bundle.price_result
+
       assert_equal 700, bundle_result[:subtotal]
       assert_equal 700, bundle_result[:final_total]
     end
@@ -92,10 +98,12 @@ module Sales
 
       coupon_submitted = { "coupon" => { discount.id.to_s => { "quantity" => "1" } } }
       form_select = CartForm.new(location: @location, inventories: @inventories, discounts: @discounts, submitted: coupon_submitted)
+
       assert_includes form_select.selected_discount_ids, discount.id
 
       zero_submitted = { "coupon" => { discount.id.to_s => { "quantity" => "0" } } }
       form_zero = CartForm.new(location: @location, inventories: @inventories, discounts: @discounts, submitted: zero_submitted)
+
       assert_not_includes form_zero.selected_discount_ids, discount.id
       assert_empty form_zero.discount_quantities_for_calculator
 
@@ -105,6 +113,7 @@ module Sales
       }
       form_with_discount = CartForm.new(location: @location, inventories: @inventories, discounts: @discounts, submitted: full_submitted)
       result = form_with_discount.price_result
+
       assert_equal 1100, result[:subtotal]
       assert_equal 50, result[:total_discount_amount]
       assert_equal 1050, result[:final_total]
@@ -115,6 +124,7 @@ module Sales
       }
       form_single = CartForm.new(location: @location, inventories: @inventories, discounts: @discounts, submitted: single_submitted)
       single_result = form_single.price_result
+
       assert_equal 550, single_result[:subtotal]
       assert_equal 50, single_result[:total_discount_amount]
       assert_equal 500, single_result[:final_total]
@@ -122,19 +132,22 @@ module Sales
 
     test "商品未選択ではバリデーションエラーになり商品を選ぶと送信できる" do
       empty_form = CartForm.new(location: @location, inventories: @inventories, discounts: @discounts, submitted: { "customer_type" => "staff" })
+
       assert_not empty_form.valid?
-      assert empty_form.errors[:base].any?
+      assert_predicate empty_form.errors[:base], :any?
 
       submitted = {
         @bento_a.id.to_s => { "quantity" => "1" },
         "customer_type" => "staff"
       }
       form = CartForm.new(location: @location, inventories: @inventories, discounts: @discounts, submitted: submitted)
-      assert form.valid?
+
+      assert_predicate form, :valid?
       assert_empty form.errors
 
       default_type = CartForm.new(location: @location, inventories: @inventories, discounts: @discounts, submitted: { @bento_a.id.to_s => { "quantity" => "1" } })
-      assert default_type.valid?
+
+      assert_predicate default_type, :valid?
       assert_equal "staff", default_type.customer_type
     end
 

--- a/test/models/sales/cart_item_test.rb
+++ b/test/models/sales/cart_item_test.rb
@@ -13,6 +13,7 @@ module Sales
 
     test "initializes with inventory, delegates attributes, and casts quantity to integer" do
       item = CartItem.new(inventory: @inventory_bento)
+
       assert_equal @inventory_bento, item.inventory
       assert_equal 0, item.quantity
       assert_equal catalogs(:daily_bento_a), item.catalog
@@ -22,28 +23,34 @@ module Sales
       assert_equal @inventory_bento.stock, item.stock
 
       custom = CartItem.new(inventory: @inventory_bento, quantity: 3)
+
       assert_equal 3, custom.quantity
 
       string_qty = CartItem.new(inventory: @inventory_bento, quantity: "5")
+
       assert_equal 5, string_qty.quantity
     end
 
     test "predicates reflect cart state and catalog category" do
       empty = CartItem.new(inventory: @inventory_bento, quantity: 0)
+
       assert_not empty.in_cart?
 
       in_cart = CartItem.new(inventory: @inventory_bento, quantity: 1)
-      assert in_cart.in_cart?
-      assert in_cart.bento?
+
+      assert_predicate in_cart, :in_cart?
+      assert_predicate in_cart, :bento?
       assert_not in_cart.side_menu?
 
       salad = CartItem.new(inventory: @inventory_salad)
-      assert salad.side_menu?
+
+      assert_predicate salad, :side_menu?
       assert_not salad.bento?
     end
 
     test "sold_out? and unit_price reflect inventory and pricing state" do
       item = CartItem.new(inventory: @inventory_bento)
+
       assert_not item.sold_out?
       assert_equal 550, item.unit_price
 
@@ -55,7 +62,8 @@ module Sales
         reserved_stock: 0
       )
       sold_out = CartItem.new(inventory: sold_out_inventory)
-      assert sold_out.sold_out?
+
+      assert_predicate sold_out, :sold_out?
 
       no_price_inventory = DailyInventory.new(
         location: locations(:city_hall),
@@ -65,6 +73,7 @@ module Sales
         reserved_stock: 0
       )
       no_price = CartItem.new(inventory: no_price_inventory)
+
       assert_nil no_price.unit_price
     end
   end

--- a/test/models/sales/cart_item_type_test.rb
+++ b/test/models/sales/cart_item_type_test.rb
@@ -13,17 +13,20 @@ module Sales
 
     test "casts hash to CartItem with integer and string quantity" do
       result = @type.cast(inventory: @inventory, quantity: 3)
+
       assert_instance_of CartItem, result
       assert_equal @inventory, result.inventory
       assert_equal 3, result.quantity
 
       string_qty = @type.cast(inventory: @inventory, quantity: "5")
+
       assert_instance_of CartItem, string_qty
       assert_equal 5, string_qty.quantity
     end
 
     test "returns CartItem as-is and nil for unsupported types" do
       item = CartItem.new(inventory: @inventory, quantity: 2)
+
       assert_same item, @type.cast(item)
 
       assert_nil @type.cast("invalid")

--- a/test/models/sales/history_calendar_test.rb
+++ b/test/models/sales/history_calendar_test.rb
@@ -17,7 +17,7 @@ module Sales
     test "日別売上合計は対象月の各日の売上金額をハッシュで返す" do
       result = @calendar.daily_totals
 
-      assert result.is_a?(Hash)
+      assert_kind_of Hash, result
       result.each_key { |date| assert_kind_of Date, date }
       assert result.values.all? { |v| v.is_a?(Numeric) && v > 0 }
     end
@@ -34,7 +34,7 @@ module Sales
       completed_amount = all_sales_on_voided_date.completed.sum(:final_amount)
       voided_amount = all_sales_on_voided_date.voided.sum(:final_amount)
 
-      assert voided_amount > 0, "テストデータに取消済み販売が存在するはず"
+      assert_operator voided_amount, :>, 0, "テストデータに取消済み販売が存在するはず"
       assert_equal completed_amount, result[voided_date] || 0
     end
 
@@ -43,17 +43,18 @@ module Sales
     test "月間サマリーは販売日数・総売上・1日平均・最高日を返す" do
       result = @calendar.monthly_summary
 
-      assert result[:business_days] > 0
-      assert result[:total_amount] > 0
-      assert result[:daily_average] > 0
+      assert_operator result[:business_days], :>, 0
+      assert_operator result[:total_amount], :>, 0
+      assert_operator result[:daily_average], :>, 0
       assert_not_nil result[:best_day]
-      assert result[:best_day][:amount] >= result[:daily_average]
+      assert_operator result[:best_day][:amount], :>=, result[:daily_average]
     end
 
     test "月間サマリーの1日平均は合計を営業日数で割った値" do
       result = @calendar.monthly_summary
 
       expected_avg = result[:total_amount] / result[:business_days]
+
       assert_equal expected_avg, result[:daily_average]
     end
 
@@ -63,10 +64,11 @@ module Sales
       target_date = 1.day.ago.to_date
       result = @calendar.daily_breakdown(target_date)
 
-      assert result.is_a?(Array)
-      assert result.length > 0
+      assert_kind_of Array, result
+      assert_operator result.length, :>, 0
 
       entry = result.first
+
       assert entry.key?(:catalog_name)
       assert entry.key?(:staff_quantity)
       assert entry.key?(:citizen_quantity)
@@ -78,6 +80,7 @@ module Sales
       result = @calendar.daily_breakdown(target_date)
 
       totals = result.map { |r| r[:total_quantity] }
+
       assert_equal totals.sort.reverse, totals
     end
 

--- a/test/models/sales/price_calculator_test.rb
+++ b/test/models/sales/price_calculator_test.rb
@@ -29,6 +29,7 @@ module Sales
       assert_equal 550, result[:final_total]
 
       item = result[:items_with_prices].first
+
       assert_equal 550, item[:unit_price]
       assert_equal catalog_prices(:daily_bento_a_regular).id, item[:catalog_price_id]
 
@@ -57,6 +58,7 @@ module Sales
       result = Sales::PriceCalculator.new(cart_items).calculate
 
       salad_item = result[:items_with_prices].find { |i| i[:catalog].side_menu? }
+
       assert_equal 150, salad_item[:unit_price]
       assert_equal catalog_prices(:salad_bundle).id, salad_item[:catalog_price_id]
       assert_equal 700, result[:subtotal]
@@ -90,6 +92,7 @@ module Sales
       result = Sales::PriceCalculator.new(cart_items).calculate
 
       salad_item = result[:items_with_prices].find { |i| i[:catalog].side_menu? }
+
       assert_equal 150, salad_item[:unit_price]
       assert_equal 2, salad_item[:quantity]
     end
@@ -100,6 +103,7 @@ module Sales
       result = Sales::PriceCalculator.new(cart_items).calculate
 
       salad_item = result[:items_with_prices].first
+
       assert_equal 250, salad_item[:unit_price]
       assert_equal catalog_prices(:salad_regular).id, salad_item[:catalog_price_id]
       assert_equal 500, result[:subtotal]
@@ -115,6 +119,7 @@ module Sales
 
       assert_equal 1, result_1[:discount_details].length
       detail = result_1[:discount_details].first
+
       assert_equal discounts(:fifty_yen_discount).id, detail[:discount_id]
       assert_equal "50円割引クーポン", detail[:discount_name]
       assert_equal 50, detail[:discount_amount]
@@ -155,6 +160,7 @@ module Sales
       result = Sales::PriceCalculator.new(cart_items, discount_quantities: discount_quantities).calculate
 
       detail = result[:discount_details].first
+
       assert_not detail[:applicable]
       assert_equal 0, detail[:discount_amount]
       assert_equal 0, result[:total_discount_amount]
@@ -234,7 +240,7 @@ module Sales
       assert_equal 550, result[:subtotal]
       assert_equal 100, result[:total_discount_amount]
       assert_equal 450, result[:final_total]
-      assert result[:final_total] >= 0
+      assert_operator result[:final_total], :>=, 0
     end
 
     test "価格未設定の商品を会計するとエラーになり商品名と価格種別が含まれる" do
@@ -250,6 +256,7 @@ module Sales
       assert_equal 1, error.missing_prices.length
 
       missing = error.missing_prices.first
+
       assert_equal catalogs(:miso_soup).id, missing[:catalog_id]
       assert_equal "味噌汁", missing[:catalog_name]
       assert_equal "regular", missing[:price_kind]
@@ -267,6 +274,7 @@ module Sales
 
       assert_equal 2, error.missing_prices.length
       catalog_names = error.missing_prices.map { |mp| mp[:catalog_name] }
+
       assert_includes catalog_names, "味噌汁"
       assert_includes catalog_names, "販売終了弁当"
     end

--- a/test/models/sales/recorder_test.rb
+++ b/test/models/sales/recorder_test.rb
@@ -7,7 +7,7 @@ module Sales
     test "弁当1個(550円)を販売記録するとSaleとSaleItemが正しく作成される" do
       sale = record_sale([ { catalog: catalogs(:daily_bento_a), quantity: 1 } ])
 
-      assert sale.persisted?
+      assert_predicate sale, :persisted?
       assert_equal locations(:city_hall), sale.location
       assert_equal 550, sale.total_amount
       assert_equal 550, sale.final_amount
@@ -15,6 +15,7 @@ module Sales
 
       assert_equal 1, sale.items.count
       sale_item = sale.items.first
+
       assert_equal catalogs(:daily_bento_a), sale_item.catalog
       assert_equal 1, sale_item.quantity
       assert_equal 550, sale_item.unit_price
@@ -41,6 +42,7 @@ module Sales
       assert_equal 700, sale.final_amount
 
       salad_item = sale.items.find_by(catalog: catalogs(:salad))
+
       assert_equal 150, salad_item.unit_price
       assert_equal catalog_prices(:salad_bundle).id, salad_item.catalog_price_id
     end
@@ -56,6 +58,7 @@ module Sales
       assert_equal 1, sale.sale_discounts.count
 
       sd = sale.sale_discounts.first
+
       assert_equal discounts(:fifty_yen_discount).id, sd.discount_id
       assert_equal 50, sd.discount_amount
       assert_equal 1, sd.quantity
@@ -71,6 +74,7 @@ module Sales
       assert_equal 1500, sale.final_amount
 
       sd = sale.sale_discounts.first
+
       assert_equal 150, sd.discount_amount
       assert_equal 3, sd.quantity
     end
@@ -91,10 +95,12 @@ module Sales
       assert_equal 2, sale.sale_discounts.count
 
       fifty = sale.sale_discounts.find_by(discount: discounts(:fifty_yen_discount))
+
       assert_equal 50, fifty.discount_amount
       assert_equal 1, fifty.quantity
 
       hundred = sale.sale_discounts.find_by(discount: discounts(:hundred_yen_discount))
+
       assert_equal 100, hundred.discount_amount
       assert_equal 1, hundred.quantity
     end

--- a/test/models/sales/refunder_test.rb
+++ b/test/models/sales/refunder_test.rb
@@ -36,12 +36,15 @@ module Sales
       assert_nil result[:corrected_sale]
 
       sale.reload
-      assert sale.voided?
+
+      assert_predicate sale, :voided?
 
       @inventory_bento_a.reload
+
       assert_equal original_stock + 1, @inventory_bento_a.stock
 
       refund = result[:refund]
+
       assert_equal sale.id, refund.original_sale_id
       assert_nil refund.corrected_sale_id
       assert_equal 550, refund.amount
@@ -64,17 +67,20 @@ module Sales
       )
 
       sale.reload
-      assert sale.voided?
+
+      assert_predicate sale, :voided?
 
       corrected_sale = result[:corrected_sale]
-      assert corrected_sale.present?
-      assert corrected_sale.completed?
+
+      assert_predicate corrected_sale, :present?
+      assert_predicate corrected_sale, :completed?
       assert_equal sale.id, corrected_sale.corrected_from_sale_id
       assert_equal 550, corrected_sale.final_amount
 
       assert_equal 550, result[:refund_amount]
 
       @inventory_bento_a.reload
+
       assert_equal original_stock + 1, @inventory_bento_a.stock
     end
 
@@ -98,6 +104,7 @@ module Sales
       )
 
       corrected_sale = result[:corrected_sale]
+
       assert_equal 550, corrected_sale.final_amount
 
       assert_equal 150, result[:refund_amount]
@@ -123,6 +130,7 @@ module Sales
       )
 
       corrected_sale = result[:corrected_sale]
+
       assert_equal 250, corrected_sale.final_amount
 
       assert_equal 450, result[:refund_amount]
@@ -235,11 +243,12 @@ module Sales
       )
 
       corrected_sale = result[:corrected_sale]
+
       assert_equal 500, corrected_sale.final_amount
 
       # 差額: 550 - 500 = 50（返金）
       assert_equal 50, result[:refund_amount]
-      assert result[:refund_amount].positive?
+      assert_predicate result[:refund_amount], :positive?
     end
 
     test "弁当A(550円)をサラダ(250円)に交換すると300円返金される" do
@@ -257,10 +266,11 @@ module Sales
       )
 
       corrected_sale = result[:corrected_sale]
+
       assert_equal 250, corrected_sale.final_amount
 
       assert_equal 300, result[:refund_amount]
-      assert result[:refund_amount].positive?
+      assert_predicate result[:refund_amount], :positive?
     end
 
     test "弁当A(550円)にサラダを追加すると-150円（追加徴収）になる" do
@@ -288,10 +298,11 @@ module Sales
 
       # 差額: 550 - 700 = -150（追加徴収）
       assert_equal(-150, result[:refund_amount])
-      assert result[:refund_amount].negative?
+      assert_predicate result[:refund_amount], :negative?
 
       # Refund レコードにマイナス値が保存される
       refund = result[:refund]
+
       assert_equal(-150, refund.amount)
     end
 
@@ -312,11 +323,12 @@ module Sales
       )
 
       corrected_sale = result[:corrected_sale]
+
       assert_equal 550, corrected_sale.final_amount
 
       # 差額: 250 - 550 = -300（追加徴収）
       assert_equal(-300, result[:refund_amount])
-      assert result[:refund_amount].negative?
+      assert_predicate result[:refund_amount], :negative?
     end
 
     test "弁当A+クーポン(500円)を弁当B+クーポン(450円)に交換すると50円返金される" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -42,6 +42,7 @@ class ActionDispatch::IntegrationTest
       username: employee_username,
       password: password
     }
+
     assert_response :redirect, "Failed to login as #{employee_username}"
     follow_redirect!
   end


### PR DESCRIPTION
## Summary

- `rubocop-minitest` (0.39.1) を development/test グループに追加
- `.rubocop.yml` に `plugins: rubocop-minitest` と `AllCops.NewCops: enable` を設定
- 既存テストに対し autocorrect で 458 件のスタイル違反を修正

## 設定方針

| Cop | 設定 | 理由 |
|---|---|---|
| `Minitest/Refute*` 系 | デフォルト (有効) | refute_* 形式を採用 |
| `Minitest/MultipleAssertions` | `Enabled: false` | Rails のテスト慣習として 1 メソッド内の複数 assertion を許容 |
| `Rails/RefuteMethods` | `Enabled: false` | `Minitest/Refute*` と方向が衝突するため明示的に無効化 |

## 修正内訳 (autocorrect)

| Cop | 件数 |
|---|---|
| `Minitest/EmptyLineBeforeAssertionMethods` | 325 |
| `Minitest/AssertPredicate` | 113 |
| `Minitest/AssertOperator` | 16 |
| `Minitest/AssertKindOf` | 3 |
| `Minitest/AssertPathExists` | 1 |

## Test plan

- [x] `bundle exec rubocop` で 0 offenses
- [x] `bin/rails test` で 471 runs / 1870 assertions / 0 failures / 0 errors
- [ ] CI が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * テストアサーション形式を標準化し、可読性を向上
  * テストコードの構造を整理

* **Chores**
  * RuboCopおよびMinitestプラグインの開発環境セットアップを追加

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kazu-2020/bento-manager/pull/175)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->