### PR TITLE
fix: 売上合計をクーポン割引前金額の合算に変更

### DIFF
--- a/app/controllers/pos/locations/sales_history_controller.rb
+++ b/app/controllers/pos/locations/sales_history_controller.rb
@@ -30,7 +30,7 @@ module Pos
 
         {
           total_count: completed_sales.size,
-          total_amount: completed_sales.sum(&:final_amount),
+          total_amount: completed_sales.sum(&:total_amount),
           voided_count: voided_sales.size
         }
       end

--- a/app/controllers/sales_histories/daily_details_controller.rb
+++ b/app/controllers/sales_histories/daily_details_controller.rb
@@ -12,7 +12,7 @@ module SalesHistories
       daily_total = Sale.completed
                         .at_location(location)
                         .in_period(date.in_time_zone.beginning_of_day, date.in_time_zone.end_of_day)
-                        .sum(:final_amount)
+                        .sum(:total_amount)
 
       render SalesHistories::DailyDetailPanel::Component.new(
         date: date,

--- a/app/models/sales/history_calendar.rb
+++ b/app/models/sales/history_calendar.rb
@@ -15,7 +15,7 @@ module Sales
         .at_location(location)
         .in_period(month_range.first, month_range.last)
         .group(jst_date_expression)
-        .sum(:final_amount)
+        .sum(:total_amount)
         .transform_keys { |date_str| Date.parse(date_str) }
     end
 

--- a/app/views/components/pos/sales_history/sale_item_card/component.rb
+++ b/app/views/components/pos/sales_history/sale_item_card/component.rb
@@ -18,7 +18,7 @@ module Pos
         end
 
         def formatted_amount
-          helpers.number_to_currency(sale.final_amount)
+          helpers.number_to_currency(sale.total_amount)
         end
 
         def customer_type_badge_class

--- a/app/views/components/sales_histories/show_page/component.rb
+++ b/app/views/components/sales_histories/show_page/component.rb
@@ -25,7 +25,7 @@ module SalesHistories
       end
 
       def total_amount
-        completed_sales.sum(&:final_amount)
+        completed_sales.sum(&:total_amount)
       end
 
       def total_transactions

--- a/app/views/components/sales_histories/transaction_table/component.html.erb
+++ b/app/views/components/sales_histories/transaction_table/component.html.erb
@@ -27,7 +27,7 @@
                   <% end %>
                 </td>
                 <td class="text-right"><%= total_quantity(sale) %></td>
-                <td class="text-right<%= " line-through" if sale.voided? %>">¥<%= number_with_delimiter(sale.final_amount) %></td>
+                <td class="text-right<%= " line-through" if sale.voided? %>">¥<%= number_with_delimiter(sale.total_amount) %></td>
               </tr>
             <% end %>
           </tbody>

--- a/test/controllers/pos/locations/sales_history_controller_test.rb
+++ b/test/controllers/pos/locations/sales_history_controller_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Pos
+  module Locations
+    class SalesHistoryControllerTest < ActionDispatch::IntegrationTest
+      fixtures :employees, :locations, :catalogs, :catalog_prices,
+               :sales, :sale_items, :coupons, :discounts, :sale_discounts
+
+      setup do
+        @location = locations(:city_hall)
+        login_as_employee(:verified_employee)
+      end
+
+      test "認証済みユーザーが当日の販売履歴にアクセスできる" do
+        get pos_location_sales_history_index_path(@location)
+
+        assert_response :success
+      end
+
+      test "未認証ユーザーはログインページにリダイレクトされる" do
+        reset!
+        get pos_location_sales_history_index_path(@location)
+
+        assert_redirected_to "/employee/login"
+      end
+
+      test "日次サマリーの売上合計はクーポン割引前の金額の合算になる" do
+        # completed_sale fixture: 今日の販売、total_amount=550, final_amount=500（50円クーポン適用）
+        get pos_location_sales_history_index_path(@location)
+
+        summary = @controller.view_assigns["daily_summary"]
+
+        assert_equal 1, summary[:total_count]
+        assert_equal 550, summary[:total_amount], "クーポン割引前金額（total_amount）を合算するべき"
+      end
+    end
+  end
+end

--- a/test/controllers/sales_histories/daily_details_controller_test.rb
+++ b/test/controllers/sales_histories/daily_details_controller_test.rb
@@ -4,7 +4,8 @@ require "test_helper"
 
 module SalesHistories
   class DailyDetailsControllerTest < ActionDispatch::IntegrationTest
-    fixtures :employees, :locations, :catalogs, :catalog_prices, :sales, :sale_items
+    fixtures :employees, :locations, :catalogs, :catalog_prices, :sales, :sale_items,
+             :coupons, :discounts, :sale_discounts
 
     setup do
       login_as_employee(:verified_employee)
@@ -17,6 +18,17 @@ module SalesHistories
       )
 
       assert_response :success
+    end
+
+    test "日別合計はクーポン割引前の金額を合算する" do
+      # completed_sale fixture: 今日の販売、total_amount=550, final_amount=500（50円クーポン適用）
+      get sales_histories_daily_detail_path(
+        location_id: locations(:city_hall).id,
+        date: Date.current.to_s
+      )
+
+      assert_response :success
+      assert_match "550", response.body
     end
 
     test "未認証ユーザーはリダイレクトされる" do

--- a/test/models/sales/history_calendar_test.rb
+++ b/test/models/sales/history_calendar_test.rb
@@ -35,13 +35,13 @@ module Sales
       result = @calendar.daily_totals
       total = result.values.sum
 
-      # total には analysis_voided の final_amount が含まれないことを検証
+      # total には analysis_voided の total_amount が含まれないことを検証
       voided_date = 2.days.ago.to_date
       all_sales_on_voided_date = Sale.at_location(@location)
                                      .in_period(voided_date.beginning_of_day, voided_date.end_of_day)
 
-      completed_amount = all_sales_on_voided_date.completed.sum(:final_amount)
-      voided_amount = all_sales_on_voided_date.voided.sum(:final_amount)
+      completed_amount = all_sales_on_voided_date.completed.sum(:total_amount)
+      voided_amount = all_sales_on_voided_date.voided.sum(:total_amount)
 
       assert_operator voided_amount, :>, 0, "テストデータに取消済み販売が存在するはず"
       assert_equal completed_amount, result[voided_date] || 0

--- a/test/models/sales/history_calendar_test.rb
+++ b/test/models/sales/history_calendar_test.rb
@@ -2,7 +2,8 @@ require "test_helper"
 
 module Sales
   class HistoryCalendarTest < ActiveSupport::TestCase
-    fixtures :locations, :employees, :catalogs, :catalog_prices, :sales, :sale_items
+    fixtures :locations, :employees, :catalogs, :catalog_prices, :sales, :sale_items,
+             :coupons, :discounts, :sale_discounts
 
     setup do
       @location = locations(:city_hall)
@@ -20,6 +21,14 @@ module Sales
       assert_kind_of Hash, result
       result.each_key { |date| assert_kind_of Date, date }
       assert result.values.all? { |v| v.is_a?(Numeric) && v > 0 }
+    end
+
+    test "日別売上合計はクーポン割引前の金額を合算する" do
+      # completed_sale fixture: 今日の販売、total_amount=550, final_amount=500（50円クーポン適用）
+      today = Date.current
+      result = @calendar.daily_totals
+
+      assert_equal 550, result[today], "クーポン割引前の total_amount を合算するべき"
     end
 
     test "日別売上合計は取消済みの販売を含まない" do


### PR DESCRIPTION
## Summary
- 売上集計の合算を `Sale#final_amount`（クーポン適用後）から `Sale#total_amount`（クーポン適用前）に変更
- pos 販売履歴・売上カレンダー・日別詳細・取引一覧・個別販売カードの 6 箇所を一貫して修正
- 売上分析系（`sale_items.line_total` ベースで元から割引前）と返金処理（実支払額ベース）は意図的に変更なし

## 背景
クーポンは簿記上「商品券」と同等扱いであり、売上計上はクーポン割引が適用される**前**の金額で行うのが会計上正しい。これまで「売上合計」表示はクーポン適用**後**の金額を合算しており、会計概念とズレていた。

## Test plan
- [x] `bin/rails test`（476 tests, 全 pass）
- [x] `bin/rubocop -a`（offense なし）
- [ ] `/pos/locations/1/sales_history` でクーポン適用販売がある日の「売上合計」がクーポン割引前金額になっていること
- [ ] `/sales_histories?month=YYYY-MM&location_id=1` のカレンダー日別合計・月間合計が割引前ベースになっていること
- [ ] 取引一覧テーブル・個別販売カードの金額が割引前ベースになっていること
- [ ] 返金画面 (`/pos/locations/:id/refunds/new`) は従来通り実支払額表示のままであること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 日次売上の集計方法を修正しました。割引前の売上金額が正確に計算・表示されるようになります。取引履歴、売上サマリー、カレンダービュー、詳細ページなど複数の画面で反映されています。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kazu-2020/bento-manager/pull/176)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->